### PR TITLE
Add Cancel All Jobs button

### DIFF
--- a/src/app/views/sessions/session/tools/job-list/job-list.component.html
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.html
@@ -1,3 +1,8 @@
+<div class="mb-1 d-flex justify-content-between align-items-center">
+  <span class="text-sm fw-bold">Jobs running: {{ runningJobCount() }}</span>
+
+  <button *ngIf="hasRunningJobs()" class="btn btn-sm btn-secondary" (click)="cancelAllJobs()">Cancel all</button>
+</div>
 <table class="table bg-white table-bordered table-sm text-sm">
   <thead>
     <tr>

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.html
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.html
@@ -1,7 +1,7 @@
 <div class="mb-1 d-flex justify-content-between align-items-center">
-  <span class="text-sm fw-bold">Jobs running: {{ runningJobCount() }}</span>
+  <span class="text-sm fw-bold">Jobs running: {{ runningJobCount }}</span>
 
-  <button *ngIf="hasRunningJobs()" class="btn btn-sm btn-secondary" (click)="cancelAllJobs()">Cancel all</button>
+  <button *ngIf="runningJobCount > 0" class="btn btn-sm btn-secondary" (click)="cancelAllJobs()">Cancel all</button>
 </div>
 <table class="table bg-white table-bordered table-sm text-sm">
   <thead>

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.less
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.less
@@ -1,0 +1,3 @@
+tr.table-active .cancel-button ::ng-deep a {
+  color: inherit;
+}

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -84,7 +84,7 @@ export class JobListComponent implements OnChanges {
       )
       .then(
         () => {
-          const runningJobs = this.jobsSorted.filter((job) => JobService.isRunning(job));
+          const runningJobs = (this.jobsSorted ?? []).filter((job) => JobService.isRunning(job));
           const promises = runningJobs.map((job) => this.sessionDataService.cancelJob(job));
           Promise.allSettled(promises).then((results) => {
             results.forEach((r, i) => {

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -76,7 +76,20 @@ export class JobListComponent implements OnChanges {
   }
 
   cancelAllJobs() {
-    this.jobsSorted.filter((job) => JobService.isRunning(job)).forEach((job) => this.sessionDataService.cancelJob(job));
+    const count = this.runningJobCount();
+    this.dialogModalService
+      .openBooleanModal(
+        "Cancel all jobs",
+        `Are you sure you want to cancel ${count} running ${count === 1 ? "job" : "jobs"}?`,
+        "Cancel all",
+        "Close",
+      )
+      .then(() => {
+        this.jobsSorted
+          .filter((job) => JobService.isRunning(job))
+          .forEach((job) => this.sessionDataService.cancelJob(job));
+      })
+      .catch(() => {});
   }
 
   isSelectedJobById(jobId: string): boolean {

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -17,6 +17,7 @@ export class JobListComponent implements OnChanges {
   jobsSorted: Job[];
 
   durationMap = new Map<string, Observable<string>>();
+  runningJobCount = 0;
 
   @Output() private jobSelected = new EventEmitter<Job>();
 
@@ -37,6 +38,8 @@ export class JobListComponent implements OnChanges {
     this.jobsSorted.forEach((job) => {
       this.durationMap.set(job.jobId, this.createDurationObservable(job));
     });
+
+    this.runningJobCount = this.jobsSorted.filter((job) => JobService.isRunning(job)).length;
   }
 
   isRunning(job: Job) {
@@ -67,16 +70,8 @@ export class JobListComponent implements OnChanges {
     this.sessionDataService.cancelJob(job);
   }
 
-  hasRunningJobs(): boolean {
-    return this.jobsSorted?.some((job) => JobService.isRunning(job));
-  }
-
-  runningJobCount(): number {
-    return this.jobsSorted?.filter((job) => JobService.isRunning(job)).length ?? 0;
-  }
-
   cancelAllJobs() {
-    const count = this.runningJobCount();
+    const count = this.runningJobCount;
     this.dialogModalService
       .openBooleanModal(
         "Cancel all jobs",

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output } from "@angular/core
 import { Job } from "chipster-js-common";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { DialogModalService } from "../../dialogmodal/dialogmodal.service";
 import { JobService } from "../../job.service";
 import { SelectionService } from "../../selection.service";
 import { SessionDataService } from "../../session-data.service";
@@ -19,7 +20,11 @@ export class JobListComponent implements OnChanges {
 
   @Output() private jobSelected = new EventEmitter<Job>();
 
-  constructor(private selectionService: SelectionService, private sessionDataService: SessionDataService) {}
+  constructor(
+    private selectionService: SelectionService,
+    private sessionDataService: SessionDataService,
+    private dialogModalService: DialogModalService,
+  ) {}
 
   ngOnChanges() {
     this.jobsSorted = this.jobs.sort((a, b) => {
@@ -54,12 +59,24 @@ export class JobListComponent implements OnChanges {
           return null;
         }
         return duration;
-      })
+      }),
     );
   }
 
   cancelJob(job: Job) {
     this.sessionDataService.cancelJob(job);
+  }
+
+  hasRunningJobs(): boolean {
+    return this.jobsSorted?.some((job) => JobService.isRunning(job));
+  }
+
+  runningJobCount(): number {
+    return this.jobsSorted?.filter((job) => JobService.isRunning(job)).length ?? 0;
+  }
+
+  cancelAllJobs() {
+    this.jobsSorted.filter((job) => JobService.isRunning(job)).forEach((job) => this.sessionDataService.cancelJob(job));
   }
 
   isSelectedJobById(jobId: string): boolean {

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -19,12 +19,12 @@ export class JobListComponent implements OnChanges {
   durationMap = new Map<string, Observable<string>>();
   runningJobCount = 0;
 
-  @Output() private jobSelected = new EventEmitter<Job>();
+  @Output() private readonly jobSelected = new EventEmitter<Job>();
 
   constructor(
-    private selectionService: SelectionService,
-    private sessionDataService: SessionDataService,
-    private dialogModalService: DialogModalService,
+    private readonly selectionService: SelectionService,
+    private readonly sessionDataService: SessionDataService,
+    private readonly dialogModalService: DialogModalService,
   ) {}
 
   ngOnChanges() {

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output } from "@angular/core
 import { Job } from "chipster-js-common";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { ErrorService } from "../../../../../core/errorhandler/error.service";
 import { DialogModalService } from "../../dialogmodal/dialogmodal.service";
 import { JobService } from "../../job.service";
 import { SelectionService } from "../../selection.service";
@@ -25,6 +26,7 @@ export class JobListComponent implements OnChanges {
     private readonly selectionService: SelectionService,
     private readonly sessionDataService: SessionDataService,
     private readonly dialogModalService: DialogModalService,
+    private readonly errorService: ErrorService,
   ) {}
 
   ngOnChanges() {
@@ -67,7 +69,8 @@ export class JobListComponent implements OnChanges {
   }
 
   cancelJob(job: Job) {
-    this.sessionDataService.cancelJob(job);
+    this.sessionDataService.cancelJob(job)
+      .catch((err) => this.errorService.showError(`Cancelling job failed for: ${job.toolName}`, err));
   }
 
   cancelAllJobs() {
@@ -80,9 +83,15 @@ export class JobListComponent implements OnChanges {
         "Close",
       )
       .then(() => {
-        this.jobsSorted
-          .filter((job) => JobService.isRunning(job))
-          .forEach((job) => this.sessionDataService.cancelJob(job));
+        const runningJobs = this.jobsSorted.filter((job) => JobService.isRunning(job));
+        const promises = runningJobs.map((job) => this.sessionDataService.cancelJob(job));
+        Promise.allSettled(promises).then((results) => {
+          results.forEach((r, i) => {
+            if (r.status === "rejected") {
+              this.errorService.showError(`Cancelling job failed for: ${runningJobs[i].toolName}`, r.reason);
+            }
+          });
+        });
       })
       .catch(() => {});
   }

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -28,7 +28,7 @@ export class JobListComponent implements OnChanges {
   ) {}
 
   ngOnChanges() {
-    this.jobsSorted = this.jobs.sort((a, b) => {
+    this.jobsSorted = [...this.jobs].sort((a, b) => {
       const d1 = new Date(a.created).getTime();
       const d2 = new Date(b.created).getTime();
       return d2 - d1;

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -82,18 +82,22 @@ export class JobListComponent implements OnChanges {
         "Cancel all",
         "Close",
       )
-      .then(() => {
-        const runningJobs = this.jobsSorted.filter((job) => JobService.isRunning(job));
-        const promises = runningJobs.map((job) => this.sessionDataService.cancelJob(job));
-        Promise.allSettled(promises).then((results) => {
-          results.forEach((r, i) => {
-            if (r.status === "rejected") {
-              this.errorService.showError(`Cancelling job failed for: ${runningJobs[i].toolName}`, r.reason);
-            }
+      .then(
+        () => {
+          const runningJobs = this.jobsSorted.filter((job) => JobService.isRunning(job));
+          const promises = runningJobs.map((job) => this.sessionDataService.cancelJob(job));
+          Promise.allSettled(promises).then((results) => {
+            results.forEach((r, i) => {
+              if (r.status === "rejected") {
+                this.errorService.showError(`Cancelling job failed for: ${runningJobs[i].toolName}`, r.reason);
+              }
+            });
           });
-        });
-      })
-      .catch(() => {});
+        },
+        () => {
+          // modal dismissed
+        },
+      );
   }
 
   isSelectedJobById(jobId: string): boolean {


### PR DESCRIPTION
## Summary
- Adds a Cancel All button to the jobs list
- Makes the cancel action visible even when a job is selected

- The backend repo has a related pull request https://github.com/chipster/chipster-web-server/pull/25. The backend change isn't critical for this to work. It removes an unnecessary error message in a quite rare case of cancelling a job that has already finished. 

## Test plan
- [ ] Open a session with running jobs
- [ ] Verify the Cancel All button appears in the jobs list
- [ ] Click Cancel All and confirm the confirmation dialog appears
- [ ] Confirm cancellation and verify all jobs are cancelled
- [ ] Select a job and verify the cancel action is still visible