### PR TITLE
Add toggle button to hide/show R input lines in screen output

### DIFF
--- a/src/app/views/sessions/session/selectiondetails/job/job.component.html
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.html
@@ -139,10 +139,15 @@
     </table>
   </div>
 
-  <h3 class="h3-xs mt-4">Screen Output</h3>
+  <div class="mb-1 mt-4 d-flex justify-content-between align-items-center">
+    <h3 class="h3-xs mb-0">Screen Output</h3>
+    <button *ngIf="isRTool" class="btn btn-sm btn-secondary" (click)="toggleInputLines()">
+      {{ hideInputLines ? "Show input lines" : "Hide input lines" }}
+    </button>
+  </div>
 
   <div class="text-sm bg-white border container">
-    <pre style="margin-bottom: 0em">{{ screenOutput }}</pre>
+    <pre style="margin-bottom: 0em">{{ filteredScreenOutput }}</pre>
     <i *ngIf="isRunning" class="fas fa-circle-notch fa-spin fa-fw"></i>
   </div>
 </div>

--- a/src/app/views/sessions/session/selectiondetails/job/job.component.html
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.html
@@ -141,7 +141,7 @@
 
   <div class="mb-1 mt-4 d-flex justify-content-between align-items-center">
     <h3 class="h3-xs mb-0">Screen Output</h3>
-    <button *ngIf="isRTool" class="btn btn-sm btn-secondary" (click)="toggleInputLines()">
+    <button *ngIf="isRTool && hasInputLines" class="btn btn-sm btn-secondary" (click)="toggleInputLines()">
       {{ hideInputLines ? "Show input lines" : "Hide input lines" }}
     </button>
   </div>

--- a/src/app/views/sessions/session/selectiondetails/job/job.component.ts
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.ts
@@ -46,9 +46,14 @@ export class JobComponent implements OnInit, OnDestroy {
     if (!this.hideInputLines || !this.screenOutput) {
       return this.screenOutput;
     }
-    return this.screenOutput
-      .split("\n")
-      .filter((line) => !line.startsWith(">"))
+    const lines = this.screenOutput.split("\n");
+    let prevWasInput = false; // this for clarity instead of reduce
+    return lines
+      .filter((line) => {
+        const isInput = line.startsWith(">") || (prevWasInput && line.startsWith("+"));
+        prevWasInput = isInput;
+        return !isInput;
+      })
       .join("\n");
   }
 
@@ -237,9 +242,9 @@ export class JobComponent implements OnInit, OnDestroy {
   }
 
   showInputs(inputs: JobInput[], tool: Tool) {
-    /* The new Chipster has misleadingly saved dataset name in input.displayName at 
-    least between 2018-2023. Try to find the displayName from the current tool 
-    instead, otherwise show the plain inputId. 
+    /* The new Chipster has misleadingly saved dataset name in input.displayName at
+    least between 2018-2023. Try to find the displayName from the current tool
+    instead, otherwise show the plain inputId.
     */
     inputs.forEach((jobInput) => {
       const _clone = clone(jobInput);

--- a/src/app/views/sessions/session/selectiondetails/job/job.component.ts
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.ts
@@ -33,8 +33,9 @@ export class JobComponent implements OnInit, OnDestroy {
   tool: Tool;
   parameterLimit = 12;
   rSessionInfoVisible = false;
-  hideInputLines = false;
+  hideInputLines = true;
   filteredScreenOutput: string = null;
+  hasInputLines = false;
   isRTool = false;
 
   toggleInputLines() {
@@ -84,7 +85,7 @@ export class JobComponent implements OnInit, OnDestroy {
         this.parameterListForView = [];
         this.inputListForView = [];
         this.outputListForView = [];
-        this.hideInputLines = false;
+        this.hideInputLines = true;
         let jobId = null;
 
         if (selectedJobs && selectedJobs.length > 0) {
@@ -134,6 +135,7 @@ export class JobComponent implements OnInit, OnDestroy {
         this.state = capitalize(job.state);
         this.screenOutput = job.screenOutput;
         this.isRTool = job.toolId?.endsWith(".R") ?? false;
+        this.hasInputLines = this.screenOutput?.split("\n").some((line) => line.startsWith(">")) ?? false;
         this.filteredScreenOutput = this.filterScreenOutput();
         this.duration = JobService.getDuration(job);
 

--- a/src/app/views/sessions/session/selectiondetails/job/job.component.ts
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.ts
@@ -33,6 +33,24 @@ export class JobComponent implements OnInit, OnDestroy {
   tool: Tool;
   parameterLimit = 12;
   rSessionInfoVisible = false;
+  hideInputLines = false;
+  filteredScreenOutput: string = null;
+  isRTool = false;
+
+  toggleInputLines() {
+    this.hideInputLines = !this.hideInputLines;
+    this.filteredScreenOutput = this.filterScreenOutput();
+  }
+
+  private filterScreenOutput(): string {
+    if (!this.hideInputLines || !this.screenOutput) {
+      return this.screenOutput;
+    }
+    return this.screenOutput
+      .split("\n")
+      .filter((line) => !line.startsWith(">"))
+      .join("\n");
+  }
 
   private unsubscribe: Subject<any> = new Subject();
   // noinspection JSMismatchedCollectionQueryUpdate
@@ -61,6 +79,7 @@ export class JobComponent implements OnInit, OnDestroy {
         this.parameterListForView = [];
         this.inputListForView = [];
         this.outputListForView = [];
+        this.hideInputLines = false;
         let jobId = null;
 
         if (selectedJobs && selectedJobs.length > 0) {
@@ -109,6 +128,8 @@ export class JobComponent implements OnInit, OnDestroy {
         this.failed = !JobService.isSuccessful(job);
         this.state = capitalize(job.state);
         this.screenOutput = job.screenOutput;
+        this.isRTool = job.toolId?.endsWith(".R") ?? false;
+        this.filteredScreenOutput = this.filterScreenOutput();
         this.duration = JobService.getDuration(job);
 
         if (job.outputs != null) {


### PR DESCRIPTION
## Summary
- Adds a 'Hide input lines' / 'Show input lines' button next to the Screen Output title in the job details view
- Button is only shown for R tools (tool ID ending with `.R`)
- Clicking the button filters out lines starting with `>` (echoed R input commands)
- Button is right-aligned, consistent with the Cancel all button style
- Filter state resets when switching to a different job