### PR TITLE
Allow downloading read-only sessions (example sessions)

### DIFF
--- a/src/app/shared/resources/sessionworker.resource.ts
+++ b/src/app/shared/resources/sessionworker.resource.ts
@@ -21,14 +21,7 @@ export class SessionWorkerResource {
 
   packageSession(sessionId: string): Observable<any> {
     return forkJoin({
-      /**
-       * Get read-write token for the session
-       *
-       * Now we can send the token in http header, so we could use the auth token as well. But we happened
-       * to have this code for getting a session token, so let's use it and maybe we should use them more
-       * widely in the future to minimize access rights.
-       */
-      token: this.sessionResource.getTokenForSession(sessionId, true),
+      token: this.sessionResource.getTokenForSession(sessionId, false),
       url: this.configService.getSessionWorkerUrl(),
     }).pipe(
       mergeMap((res) =>


### PR DESCRIPTION
## Summary

- Request a read-only session token for packaging instead of read-write, so users with only read access (e.g. example sessions) can initiate a download
- Remove the write-access guard (`[disabled]`) from the Download button — read-only users should be able to download sessions they can read

## Context

Downloading a session packages it into a zip file via the session-worker. Previously the frontend requested a **read-write** session token for this, which the backend correctly rejected for read-only sessions (e.g. example sessions shared with `readWrite: false`). The result was a misleading "Authentication failed / Log in" error even though the user was fully authenticated.

The companion PR in chipster-web-server makes the session-worker use its own service credentials for the write operations (creating/uploading/deleting the temporary zip dataset), so only read access is required from the user's side.

## Test plan

- [ ] Log in as a regular user and open the session list
- [ ] Confirm the Download option is now enabled on example sessions
- [ ] Click Download on an example session → spinner appears → zip file downloads
- [ ] Confirm Rename and Share are still disabled on example sessions (they retain the `[disabled]` guard)
- [ ] Confirm Download still works on the user's own read-write sessions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)