### PR TITLE
Remove angular2-hotkeys, replace with native hotkey service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "ag-grid-angular": "^32.2.1",
         "ag-grid-community": "^32.2.1",
         "angular-split": "^17.2.0",
-        "angular2-hotkeys": "^16.0.1",
         "bootstrap": "^5.2.3",
         "chipster-js-common": "^1.5.9",
         "d3": "^7",
@@ -277,6 +276,7 @@
       "integrity": "sha512-la4CFvs5PcRWSkQ/H7TB5cPZirFVA9GoWk5LzIk8si6VjWBJRm8b3keKJoC9LlNeABRUIR5z0ocYkyQQUhdMfg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
@@ -305,6 +305,7 @@
       "integrity": "sha512-uIttrQ2cQ2PWAFFVPeCoNR8xvs7tPJ2i8gzqsIwYdge107xDC6u9CqfgmBqPDSFpWj+IiC2Jwcm8Z4HYKU4+7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "18.2.6",
         "jsonc-parser": "3.3.1",
@@ -423,6 +424,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-18.2.6.tgz",
       "integrity": "sha512-vy9wy+Q9beiRxkEO8wNxFQ63AqAujGvk8AUHepxxIT7QNNc512TNKz8uH+feWDPO38Dm2obwYQHMGzs3WO7pUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -541,6 +543,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.2.6.tgz",
       "integrity": "sha512-89793ow+wrI1c7C6kyMbnweLNIZHzXthosxAEjipRZGBrqBYjvTtkE45Fl+5yBa3JO7bAhyGkUnEoyvWtZIAEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -557,6 +560,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.2.6.tgz",
       "integrity": "sha512-3tX2/Qw+bZ8XzKitviH8jzNGyY0uohhehhBB57OJOCc+yr4ojy/7SYFnun1lSsRnDztdCE461641X4iQLCQ94w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -577,6 +581,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-18.2.6.tgz",
       "integrity": "sha512-b5x9STfjNiNM/S0D+CnqRP9UOxPtSz1+RlCH5WdOMiW/p8j5p6dBix8YYgTe6Wg3OD7eItD2pnFQKgF/dWiopA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.25.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -605,6 +610,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.2.6.tgz",
       "integrity": "sha512-PjFad2j4YBwLVTw+0Te8CJCa/tV0W8caTHG8aOjj3ObdL6ihGI+FKnwerLc9RVzDFd14BOO4C6/+LbOQAh3Ltw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -621,6 +627,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-18.2.6.tgz",
       "integrity": "sha512-quGkUqTxlBaLB8C/RnpfFG57fdmNF5RQ+368N89Ma++2lpIsVAHaGZZn4yOyo3wNYaM2jBxNqaYxOzZNUl5Tig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -649,6 +656,7 @@
       "resolved": "https://registry.npmjs.org/@angular/localize/-/localize-18.2.6.tgz",
       "integrity": "sha512-4NZwh5EAyXItmwv6hqilV+JyN8DT+d+S1rW+M1IwJqC9asCDfpFqipKpuQF81LQKeLH0mn/phNfVbnJCLP0Tkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.25.2",
         "@types/babel__core": "7.20.5",
@@ -673,6 +681,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.2.6.tgz",
       "integrity": "sha512-RA8UMiYNLga+QMwpKcDw1357gYPfPyY/rmLeezMak//BbsENFYQOJ4Z6DBOBNiPlHxmBsUJMGaKdlpQhfCROyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -753,6 +762,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -3418,6 +3428,7 @@
       "integrity": "sha512-b2BudQY/Si4Y2a0PdZZL6BeJtl8llgeZa7U2j47aaJSCeAl1e4UI7y8a9bSkO3o/ZbZrgT5muy/34JbsjfIWxA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^2.4.7",
         "@inquirer/confirm": "^3.1.22",
@@ -5325,12 +5336,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mousetrap": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
-      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
-      "license": "MIT"
-    },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -5347,6 +5352,7 @@
       "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5526,6 +5532,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5691,7 +5698,6 @@
       "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.7.0",
         "@typescript-eslint/visitor-keys": "8.7.0"
@@ -5710,7 +5716,6 @@
       "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5725,7 +5730,6 @@
       "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.7.0",
         "@typescript-eslint/visitor-keys": "8.7.0",
@@ -5755,7 +5759,6 @@
       "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "8.7.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -6018,6 +6021,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6112,6 +6116,7 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-32.2.1.tgz",
       "integrity": "sha512-mrnm1DnLI9Wd408mMwP+6p7lbTC3FYgzNIUPygBvNh3SzZnbzTEUJF/BTKXi+MARWtG5S0IMUYy4hqBiLbobaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ag-charts-types": "10.2.0"
       }
@@ -6149,6 +6154,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6203,17 +6209,6 @@
         "@angular/common": ">=16.0.0",
         "@angular/core": ">=16.0.0",
         "rxjs": ">=7.0.0"
-      }
-    },
-    "node_modules/angular2-hotkeys": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/angular2-hotkeys/-/angular2-hotkeys-16.0.1.tgz",
-      "integrity": "sha512-AyjUrBaWKtr7xRfFybazkzeWo6PTooDnmr9QqD962AcJKW4mH3lh1L8roZLJtocCkODHQOaCEVldM4MTDyR0VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.9",
-        "mousetrap": "^1.6.5",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -6830,6 +6825,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -8184,6 +8180,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8713,16 +8710,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/engine.io": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.1.tgz",
@@ -9089,6 +9076,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9253,6 +9241,7 @@
       "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -11672,7 +11661,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.3.0.tgz",
       "integrity": "sha512-zsOmeBKESky4toybvWEikRiZ0jHoBEu79wNArLfMdSnlLMZx3Xcp6CSm2sUcYyoJC+Uyj8LBJap/MUbVSfJ27g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -11848,6 +11838,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -12226,6 +12217,7 @@
       "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13259,12 +13251,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mousetrap": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
-      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
-      "license": "Apache-2.0 WITH LLVM-exception"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -14665,6 +14651,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -15389,6 +15376,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -16642,6 +16630,7 @@
       "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -16696,6 +16685,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16942,7 +16932,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "2.2.1",
@@ -17088,6 +17079,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17373,6 +17365,7 @@
       "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17950,6 +17943,7 @@
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -18027,6 +18021,7 @@
       "integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18196,6 +18191,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "ag-grid-angular": "^32.2.1",
     "ag-grid-community": "^32.2.1",
     "angular-split": "^17.2.0",
-    "angular2-hotkeys": "^16.0.1",
     "bootstrap": "^5.2.3",
     "chipster-js-common": "^1.5.9",
     "d3": "^7",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <ch-navigation></ch-navigation>
 
-<hotkeys-cheatsheet></hotkeys-cheatsheet>
+<ch-hotkey-cheatsheet></ch-hotkey-cheatsheet>
 
 <ch-error></ch-error>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,16 @@
-import { Component } from "@angular/core";
+import { Component, HostListener } from "@angular/core";
+import { HotkeyService } from "./shared/services/hotkey.service";
 
 @Component({
   selector: "ch-app-root",
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.css"],
 })
-export class AppComponent {}
+export class AppComponent {
+  constructor(private readonly hotkeyService: HotkeyService) {}
+
+  @HostListener("document:keydown", ["$event"])
+  onKeydown(event: KeyboardEvent) {
+    this.hotkeyService.handleKeydown(event);
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,6 @@ import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { StoreModule } from "@ngrx/store";
-import { HotkeyModule } from "angular2-hotkeys";
 import { ToastrModule } from "ngx-toastr";
 import { setAppInjector } from "./app-injector";
 import { AppRoutingModule } from "./app-routing.module";
@@ -102,7 +101,6 @@ import { TermsComponent } from "./views/terms/terms.component";
     ToastrModule.forRoot({
       toastComponent: ActionToastComponent,
     }),
-    HotkeyModule.forRoot({ cheatSheetCloseEsc: true }),
     AppRoutingModule,
   ],
   providers: [

--- a/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.html
+++ b/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.html
@@ -1,0 +1,17 @@
+<ng-template #content>
+  <div class="modal-header">
+    <h4 class="modal-title">Keyboard shortcuts</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="close()"></button>
+  </div>
+  <div class="modal-body">
+    <dl>
+      <ng-container *ngFor="let shortcut of shortcuts">
+        <dt><kbd>{{ shortcut.key }}</kbd></dt>
+        <dd>{{ shortcut.description }}</dd>
+      </ng-container>
+    </dl>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="close()">Close</button>
+  </div>
+</ng-template>

--- a/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.less
+++ b/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.less
@@ -1,0 +1,24 @@
+ngb-modal-window.ch-hotkey-cheatsheet {
+  .modal-body {
+    dl {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.25rem 1rem;
+      margin: 0;
+
+      dt,
+      dd {
+        margin: 0;
+        align-self: center;
+      }
+    }
+
+    kbd {
+      text-transform: uppercase;
+    }
+  }
+
+  .modal-footer kbd {
+    text-transform: uppercase;
+  }
+}

--- a/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.ts
+++ b/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from "@angular/core";
+import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
+import { HotkeyService } from "../../services/hotkey.service";
+
+@Component({
+  selector: "ch-hotkey-cheatsheet",
+  templateUrl: "./hotkey-cheatsheet.component.html",
+  styleUrls: ["./hotkey-cheatsheet.component.less"],
+  encapsulation: ViewEncapsulation.None,
+})
+export class HotkeyCheatsheetComponent implements OnInit, OnDestroy {
+  @ViewChild("content") contentTemplate!: TemplateRef<unknown>;
+
+  private unregister!: () => void;
+  private modalRef: NgbModalRef | null = null;
+
+  constructor(
+    private readonly hotkeyService: HotkeyService,
+    private readonly modalService: NgbModal,
+  ) {}
+
+  ngOnInit() {
+    this.unregister = this.hotkeyService.register("?", "Show keyboard shortcuts", () => {
+      if (this.hotkeyService.getShortcuts().length > 0) {
+        this.toggle();
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.unregister();
+    this.modalRef?.close();
+  }
+
+  get shortcuts() {
+    return this.hotkeyService.getShortcuts().sort((a, b) => {
+      if (a.key === "?") return 1;
+      if (b.key === "?") return -1;
+      return 0;
+    });
+  }
+
+  close() {
+    this.modalRef?.close();
+  }
+
+  toggle() {
+    if (this.modalRef) {
+      this.modalRef.close();
+    } else {
+      this.modalRef = this.modalService.open(this.contentTemplate, { windowClass: "ch-hotkey-cheatsheet" });
+      this.modalRef.hidden.subscribe(() => {
+        this.modalRef = null;
+      });
+    }
+  }
+}

--- a/src/app/shared/components/search-box/search-box.component.ts
+++ b/src/app/shared/components/search-box/search-box.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from "@angular/core";
-import { Hotkey, HotkeysService } from "angular2-hotkeys";
+import { HotkeyService } from "../../services/hotkey.service";
 
 @Component({
   selector: "ch-search-box",
@@ -25,27 +25,22 @@ export class SearchBoxComponent implements OnInit, OnDestroy {
 
   searchTerm: string;
 
-  private hotkey: Hotkey | Hotkey[];
+  private unregisterHotkey: (() => void) | null = null;
 
-  constructor(private hotkeysService: HotkeysService) {}
+  constructor(private readonly hotkeyService: HotkeyService) {}
 
   ngOnInit() {
-    // add focus hotkey
-    this.hotkey = this.hotkeysService.add(
-      new Hotkey(
+    if (this.focusHotkey) {
+      this.unregisterHotkey = this.hotkeyService.register(
         this.focusHotkey,
-        (event: KeyboardEvent): boolean => {
-          this.focus();
-          return false; // Prevent bubbling
-        },
-        undefined,
-        this.focusHotkeyDescription
-      )
-    );
+        this.focusHotkeyDescription,
+        () => this.focus(),
+      );
+    }
   }
 
   ngOnDestroy() {
-    this.hotkeysService.remove(this.hotkey);
+    this.unregisterHotkey?.();
   }
 
   focus() {

--- a/src/app/shared/services/hotkey.service.ts
+++ b/src/app/shared/services/hotkey.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@angular/core";
 
 @Injectable({ providedIn: "root" })
 export class HotkeyService {
-  private shortcuts = new Map<string, { callback: () => void; description: string }>();
+  private readonly shortcuts = new Map<string, { callback: () => void; description: string }>();
 
   register(key: string, description: string, callback: () => void): () => void {
     this.shortcuts.set(key.toLowerCase(), { callback, description });
@@ -11,6 +11,10 @@ export class HotkeyService {
 
   getShortcuts(): Array<{ key: string; description: string }> {
     return Array.from(this.shortcuts.entries()).map(([key, { description }]) => ({ key, description }));
+  }
+
+  openShortcuts(): void {
+    this.shortcuts.get("?")?.callback();
   }
 
   handleKeydown(event: KeyboardEvent): void {

--- a/src/app/shared/services/hotkey.service.ts
+++ b/src/app/shared/services/hotkey.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({ providedIn: "root" })
+export class HotkeyService {
+  private shortcuts = new Map<string, { callback: () => void; description: string }>();
+
+  register(key: string, description: string, callback: () => void): () => void {
+    this.shortcuts.set(key.toLowerCase(), { callback, description });
+    return () => this.shortcuts.delete(key.toLowerCase());
+  }
+
+  getShortcuts(): Array<{ key: string; description: string }> {
+    return Array.from(this.shortcuts.entries()).map(([key, { description }]) => ({ key, description }));
+  }
+
+  handleKeydown(event: KeyboardEvent): void {
+    if (
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement ||
+      event.target instanceof HTMLSelectElement
+    ) {
+      return;
+    }
+    const shortcut = this.shortcuts.get(event.key.toLowerCase());
+    if (shortcut) {
+      event.preventDefault();
+      shortcut.callback();
+    }
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,6 +8,7 @@ import { ActionToastComponent } from "./components/action-toast";
 import { DummyRouteComponent } from "./components/dummy-route.component";
 import { NewsItemComponent } from "./components/news/news-item.component";
 import { NewsListComponent } from "./components/news/news-list.component";
+import { HotkeyCheatsheetComponent } from "./components/hotkey-cheatsheet/hotkey-cheatsheet.component";
 import { SearchBoxComponent } from "./components/search-box/search-box.component";
 import { SettingsComponent } from "./components/settings/settings.component";
 import { StatusComponent } from "./components/status.component";
@@ -58,6 +59,7 @@ import { SchedulerResource } from "./resources/scheduler-resource";
     CategoryPipe,
     ModulePipe,
     SecondsPipe,
+    HotkeyCheatsheetComponent,
     SearchBoxComponent,
     StatusComponent,
     SettingsComponent,
@@ -102,6 +104,7 @@ import { SchedulerResource } from "./resources/scheduler-resource";
     CategoryPipe,
     ModulePipe,
     SecondsPipe,
+    HotkeyCheatsheetComponent,
     SearchBoxComponent,
     StatusComponent,
     SettingsComponent,

--- a/src/app/views/navigation/navigation.component.html
+++ b/src/app/views/navigation/navigation.component.html
@@ -65,6 +65,10 @@
               <i class="fas fa-cog fa-fw lighter"></i>
               Settings
             </a>
+            <a ngbDropdownItem (click)="openKeyboardShortcuts()">
+              <i class="fas fa-keyboard fa-fw lighter"></i>
+              Keyboard shortcuts
+            </a>
             <div class="dropdown-divider"></div>
             <a ngbDropdownItem [routerLink]="routerLinkHome" (click)="logout()">
               <i class="fas fa-sign-out-alt fa-fw lighter"></i>

--- a/src/app/views/navigation/navigation.component.ts
+++ b/src/app/views/navigation/navigation.component.ts
@@ -8,6 +8,7 @@ import { AccountComponent } from "../../shared/components/account/account.compon
 import { NewsItem } from "../../shared/components/news/NewsItem";
 import { SettingsComponent } from "../../shared/components/settings/settings.component";
 import { ConfigService } from "../../shared/services/config.service";
+import { HotkeyService } from "../../shared/services/hotkey.service";
 import { NewsService } from "../../shared/services/news.service";
 import { PreferencesService } from "../../shared/services/preferences.service";
 import { RouteService } from "../../shared/services/route.service";
@@ -43,6 +44,7 @@ export class NavigationComponent implements OnInit {
     private modalService: NgbModal,
     private newsService: NewsService,
     private preferencesService: PreferencesService,
+    private readonly hotkeyService: HotkeyService,
   ) {}
 
   ngOnInit() {
@@ -132,6 +134,10 @@ export class NavigationComponent implements OnInit {
 
   openSettings(): void {
     this.modalService.open(SettingsComponent);
+  }
+
+  openKeyboardShortcuts(): void {
+    this.hotkeyService.openShortcuts();
   }
 
   getAccountName(): string {

--- a/src/app/views/sessions/session/tools/tools.component.ts
+++ b/src/app/views/sessions/session/tools/tools.component.ts
@@ -2,8 +2,9 @@ import { DOCUMENT } from "@angular/common";
 import { Component, Inject, Input, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { NgbDropdownConfig, NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { Store } from "@ngrx/store";
-import { Hotkey, HotkeysService } from "angular2-hotkeys";
 import { Category, Dataset, Job, Module, SessionEvent, Tool } from "chipster-js-common";
+import { NgSelectComponent } from "@ng-select/ng-select";
+import { HotkeyService } from "../../../../shared/services/hotkey.service";
 import { cloneDeep } from "lodash-es";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Subject, combineLatest, of } from "rxjs";
@@ -90,6 +91,11 @@ export class ToolsComponent implements OnInit, OnDestroy {
   @ViewChild("searchBox")
   searchBox;
 
+  @ViewChild("searchTool")
+  searchTool: NgSelectComponent;
+
+  private unregisterHotkey: (() => void) | null = null;
+
   private toolsMap: Map<string, Tool>;
 
   public selectedTool: SelectedTool;
@@ -117,8 +123,6 @@ export class ToolsComponent implements OnInit, OnDestroy {
   compactToolList = true;
 
   public searchBoxModel: ToolSearchListItem;
-  private searchBoxHotkey: Hotkey | Hotkey[];
-
   private lastJobStartedToastId: number;
 
   // use to signal that parameters have been changed and need to be validated
@@ -141,7 +145,6 @@ export class ToolsComponent implements OnInit, OnDestroy {
     private sessionDataService: SessionDataService,
     public toolService: ToolService,
     private modalService: NgbModal,
-    private hotkeysService: HotkeysService,
     private toastrService: ToastrService,
     private errorService: ErrorService,
     private datasetModalService: DatasetModalService,
@@ -150,6 +153,7 @@ export class ToolsComponent implements OnInit, OnDestroy {
     dropdownConfig: NgbDropdownConfig,
     private ngbModal: NgbModal,
     private schedulerResource: SchedulerResource,
+    private hotkeyService: HotkeyService,
   ) {
     // prevent dropdowns from closing on click inside the dropdown
     // eslint-disable-next-line no-param-reassign
@@ -169,8 +173,6 @@ export class ToolsComponent implements OnInit, OnDestroy {
 
     this.subscribeToJobEvents();
 
-    this.addHotKeys();
-
     if (this.modules[0] != null) {
       this.selectModuleAndFirstCategoryAndFirstTool(this.modules[0]);
     } else {
@@ -178,16 +180,17 @@ export class ToolsComponent implements OnInit, OnDestroy {
     }
 
     this.toolsMap = new Map(this.toolsArray.map((tool: Tool) => [tool.name.id, tool]));
+
+    this.unregisterHotkey = this.hotkeyService.register("t", "Find tool", () => this.searchTool?.open());
   }
 
   ngOnDestroy() {
+    this.unregisterHotkey?.();
     this.clearStoreToolSelections();
     this.parametersChanged$ = null;
     this.resourcesChanged$ = null;
     this.unsubscribe.next(null);
     this.unsubscribe.complete();
-    this.hotkeysService.remove(this.searchBoxHotkey);
-
     if (this.manualModalRef != null) {
       this.manualModalRef.close();
     }
@@ -650,21 +653,6 @@ export class ToolsComponent implements OnInit, OnDestroy {
         },
         (err) => this.errorService.showError("failed to update jobs", err),
       );
-  }
-
-  private addHotKeys() {
-    // add search box hotkey
-    this.searchBoxHotkey = this.hotkeysService.add(
-      new Hotkey(
-        "t",
-        (): boolean => {
-          this.searchBox.focus();
-          return false;
-        },
-        undefined,
-        "Find tool",
-      ),
-    );
   }
 
   onDefineSamples() {


### PR DESCRIPTION
## Summary

- Removes `angular2-hotkeys` (v16.x, unmaintained for Angular 19+) as a blocker for the upcoming Angular 21 upgrade
- Replaces it with a native `HotkeyService` — a small injectable service backed by a `Map`, with automatic input-field filtering so hotkeys don't fire while typing
- Migrates the two active hotkeys (`t` → find tool, `f` → find file) to the new service with identical behaviour
- Adds a `HotkeyCheatsheetComponent` that opens a standard ng-bootstrap modal (press `?` to toggle), replacing the old `<hotkeys-cheatsheet>` component

## What changed

- `HotkeyService` — register/unregister pattern returning a cleanup function; `handleKeydown` skips input/textarea/select targets
- `AppComponent` — global `document:keydown` listener delegates to `HotkeyService`
- `SearchBoxComponent` — swapped `HotkeysService` for `HotkeyService`, same lifecycle (register on init, unregister on destroy)
- `ToolsComponent` — removed redundant direct hotkey registration (the `t` key is now registered here via `HotkeyService` pointing to the ng-select, since `ch-tool-list-accordion` is only in the DOM when the 3-way split is active)
- `HotkeyCheatsheetComponent` — ng-bootstrap modal opened via `NgbModal`, styled to match other modals in the app; supports close via `×` button, Close button, `Esc`, and `?`

## Test plan

- [ ] Navigate to session view, press `t` → "Find tool" ng-select opens
- [ ] Press `f` → "Find file" search box gains focus
- [ ] Press `t` or `f` while typing in a text input → nothing happens
- [ ] Press `?` → keyboard shortcuts modal opens, listing all active shortcuts
- [ ] Press `Esc` or `?` again → modal closes
- [ ] Click `×` or Close button → modal closes
- [ ] Navigate away from session view → `t` and `f` no longer fire