### PR TITLE
Add j shortcut to toggle jobs list

### DIFF
--- a/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
+++ b/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { Dataset, Job, SessionEvent, Tool } from "chipster-js-common";
 import { EMPTY, Observable, from as observableFrom } from "rxjs";
 import { catchError } from "rxjs/operators";
@@ -144,15 +144,12 @@ export class DialogModalService {
     return DialogModalService.observableFromPromiseWithDismissHandling(modalRef.result);
   }
 
-  public openJobsModal(jobs: Job[], tools: Tool[], sessionData: SessionData) {
-    const modalRef = this.modalService.open(JobsModalComponent, {
-      size: "xl",
-    });
+  public openJobsModal(jobs: Job[], tools: Tool[], sessionData: SessionData): NgbModalRef {
+    const modalRef = this.modalService.open(JobsModalComponent, { size: "xl" });
     modalRef.componentInstance.jobs = jobs;
     modalRef.componentInstance.tools = tools;
     modalRef.componentInstance.sessionData = sessionData;
-
-    return DialogModalService.observableFromPromiseWithDismissHandling(modalRef.result);
+    return modalRef;
   }
 
   openSpinnerModal(message, observable) {

--- a/src/app/views/sessions/session/tools/tools.component.ts
+++ b/src/app/views/sessions/session/tools/tools.component.ts
@@ -94,7 +94,7 @@ export class ToolsComponent implements OnInit, OnDestroy {
   @ViewChild("searchTool")
   searchTool: NgSelectComponent;
 
-  private unregisterHotkey: (() => void) | null = null;
+  private readonly unregisterHotkeys: Array<() => void> = [];
 
   private toolsMap: Map<string, Tool>;
 
@@ -133,6 +133,7 @@ export class ToolsComponent implements OnInit, OnDestroy {
   manualModalRef: any;
 
   parametersModalRef: NgbModalRef;
+  private jobsModalRef: NgbModalRef | null = null;
 
   constructor(
     @Inject(DOCUMENT) private document: any,
@@ -181,11 +182,14 @@ export class ToolsComponent implements OnInit, OnDestroy {
 
     this.toolsMap = new Map(this.toolsArray.map((tool: Tool) => [tool.name.id, tool]));
 
-    this.unregisterHotkey = this.hotkeyService.register("t", "Find tool", () => this.searchTool?.open());
+    this.unregisterHotkeys.push(
+      this.hotkeyService.register("t", "Find tool", () => this.searchTool?.open()),
+      this.hotkeyService.register("j", "Open jobs", () => this.toggleJobs()),
+    );
   }
 
   ngOnDestroy() {
-    this.unregisterHotkey?.();
+    this.unregisterHotkeys.forEach((fn) => fn());
     this.clearStoreToolSelections();
     this.parametersChanged$ = null;
     this.resourcesChanged$ = null;
@@ -346,6 +350,22 @@ export class ToolsComponent implements OnInit, OnDestroy {
       this.toolsArray,
       this.sessionData,
     );
+  }
+
+  public toggleJobs() {
+    if (this.jobsModalRef) {
+      this.jobsModalRef.close();
+    } else {
+      this.selectionHandlerService.setJobSelection([]);
+      this.jobsModalRef = this.dialogModalService.openJobsModal(
+        this.sessionDataService.getJobList(this.sessionData),
+        this.toolsArray,
+        this.sessionData,
+      );
+      this.jobsModalRef.hidden.subscribe(() => {
+        this.jobsModalRef = null;
+      });
+    }
   }
 
   public searchBoxSelect(item) {


### PR DESCRIPTION
## Summary

- Adds keyboard shortcut `j` to toggle the jobs modal open/closed in the session view
- Refactors `openJobsModal` in `DialogModalService` to return `NgbModalRef` instead of an Observable, removing code duplication in the toggle logic

## What changed

- `DialogModalService.openJobsModal` — now returns `NgbModalRef` directly (both existing callers ignored the Observable return value)
- `ToolsComponent` — adds `toggleJobs()` which opens the jobs modal if closed, closes it if already open; registers the `j` hotkey alongside the existing `t` hotkey

## Test plan

- [ ] In session view, press `j` → jobs modal opens
- [ ] Press `j` again → jobs modal closes
- [ ] Press `?` → keyboard shortcuts cheat sheet lists `j` as "Open jobs"
- [ ] Jobs button in the toolbar still opens the modal as before