### PR TITLE
Fix nav dropdown cursor by using button elements for actions

### DIFF
--- a/src/app/views/navigation/navigation.component.html
+++ b/src/app/views/navigation/navigation.component.html
@@ -57,18 +57,18 @@
             {{ getAccountName() }}
           </a>
           <div ngbDropdownMenu aria-labelledby="navbarDropdown2" class="dropdown-menu dropdown-menu-end">
-            <a ngbDropdownItem (click)="openAccount()">
+            <button ngbDropdownItem (click)="openAccount()">
               <i class="fas fa-user fa-fw lighter"></i>
               Account
-            </a>
-            <a ngbDropdownItem (click)="openSettings()">
+            </button>
+            <button ngbDropdownItem (click)="openSettings()">
               <i class="fas fa-cog fa-fw lighter"></i>
               Settings
-            </a>
-            <a ngbDropdownItem (click)="openKeyboardShortcuts()">
+            </button>
+            <button ngbDropdownItem (click)="openKeyboardShortcuts()">
               <i class="fas fa-keyboard fa-fw lighter"></i>
               Keyboard shortcuts
-            </a>
+            </button>
             <div class="dropdown-divider"></div>
             <a ngbDropdownItem [routerLink]="routerLinkHome" (click)="logout()">
               <i class="fas fa-sign-out-alt fa-fw lighter"></i>


### PR DESCRIPTION
## Summary

- Replaces `<a ngbDropdownItem>` with `<button ngbDropdownItem>` for the three action items in the account dropdown (Account, Settings, Keyboard shortcuts)
- `<button>` elements get pointer cursor natively; `<a>` without `href` does not, causing the text cursor to appear on hover
- Logout remains as `<a>` since it uses `[routerLink]` for navigation

## What changed

- `navigation.component.html` — Account, Settings, Keyboard shortcuts items changed from `<a>` to `<button>`

## Test plan

- [ ] Hover over Account, Settings, Keyboard shortcuts in the nav dropdown → pointer cursor shown
- [ ] Logout still navigates correctly
- [ ] All three action items still open their respective modals on click