### PR TITLE
Add arrow key navigation to jobs modal

### DIFF
--- a/src/app/views/sessions/session/jobs-modal/jobs-modal.component.ts
+++ b/src/app/views/sessions/session/jobs-modal/jobs-modal.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { AfterViewInit, Component, HostListener, Input, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 import { Job, Tool } from "chipster-js-common";
 import log from "loglevel";
@@ -10,6 +10,7 @@ import { SelectionHandlerService } from "../selection-handler.service";
 import { SelectionService } from "../selection.service";
 import { SessionDataService } from "../session-data.service";
 import { SessionEventService } from "../session-event.service";
+import { JobListComponent } from "../tools/job-list/job-list.component";
 
 @Component({
   selector: "ch-jobs-modal",
@@ -46,8 +47,13 @@ export class JobsModalComponent implements OnInit, AfterViewInit, OnDestroy {
       } else {
         log.warn("scrolling to job failed, element id not found: ", rowId);
       }
+    } else if (this.jobListComponent?.jobsSorted.length > 0) {
+      // auto-select first job to enable immediate arrow key navigation; setTimeout defers past view check cycle (NG0100)
+      setTimeout(() => this.onJobSelection(this.jobListComponent.jobsSorted[0]));
     }
   }
+
+  @ViewChild(JobListComponent) jobListComponent!: JobListComponent;
 
   jobs: Job[];
   @Input() tools: Tool[];
@@ -59,6 +65,17 @@ export class JobsModalComponent implements OnInit, AfterViewInit, OnDestroy {
    * @param job
    *
    */
+  @HostListener("keydown", ["$event"])
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.jobListComponent?.navigateJob(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.jobListComponent?.navigateJob(-1);
+    }
+  }
+
   onJobSelection(job: Job) {
     this.selectionHandlerService.setJobSelection([job]);
   }

--- a/src/app/views/sessions/session/tools/job-list/job-list.component.ts
+++ b/src/app/views/sessions/session/tools/job-list/job-list.component.ts
@@ -56,6 +56,17 @@ export class JobListComponent implements OnChanges {
     this.jobSelected.emit(job);
   }
 
+  public navigateJob(direction: 1 | -1): void {
+    if (!this.jobsSorted?.length) {
+      return;
+    }
+    const current = this.jobsSorted.findIndex((j) => this.selectionService.isSelectedJobById(j.jobId));
+    const next = Math.max(0, Math.min(this.jobsSorted.length - 1, (current === -1 ? 0 : current) + direction));
+    const job = this.jobsSorted[next];
+    this.jobSelected.emit(job);
+    document.getElementById(`job-id-${job.jobId}`)?.scrollIntoView({ block: "nearest" });
+  }
+
   createDurationObservable(job: Job): Observable<string> {
     return JobService.getDuration(job).pipe(
       map((duration) => {


### PR DESCRIPTION
## Summary

- Auto-selects the first job when the jobs modal opens (enabling immediate keyboard navigation)
- ArrowDown/ArrowUp move selection through the job list; selected row scrolls into view
- ArrowDown at the bottom and ArrowUp at the top stay on the last/first job

## Test plan

- Open session view, press `j` → jobs modal opens, first job is highlighted
- Press ArrowDown → selection moves to next job, modal body does not scroll unexpectedly
- Press ArrowUp → selection moves back; stays on first job at the top
- Press ArrowDown at the bottom → stays on last job
- Click a job directly → still works as before
- Open modal with no jobs → no error on arrow key press
- Open modal via "Show job" in dataset context menu → pre-selected job is preserved, not overridden by auto-select