### PR TITLE
Add Reset to previous option to phenodata editor

### DIFF
--- a/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.html
+++ b/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.html
@@ -8,6 +8,6 @@
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary me-auto" (click)="cancel()">{{ cancelButtonText }}</button>
   <button *ngIf="action3ButtonText" type="button" class="btn btn-info me-1" (click)="action3()" [disabled]="action3Disabled">{{ action3ButtonText }}</button>
-  <button type="button" class="btn btn-info me-1" (click)="action2()">{{ action2ButtonText }}</button>
-  <button type="submit" class="btn btn-info" (click)="action1()" #submitButton>{{ action1ButtonText }}</button>
+  <button type="button" class="btn btn-info me-1" (click)="action2()" [disabled]="action2Disabled">{{ action2ButtonText }}</button>
+  <button type="submit" class="btn btn-info" (click)="action1()" [disabled]="action1Disabled" #submitButton>{{ action1ButtonText }}</button>
 </div>

--- a/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.html
+++ b/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.html
@@ -7,6 +7,7 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary me-auto" (click)="cancel()">{{ cancelButtonText }}</button>
+  <button *ngIf="action3ButtonText" type="button" class="btn btn-info me-1" (click)="action3()" [disabled]="action3Disabled">{{ action3ButtonText }}</button>
   <button type="button" class="btn btn-info me-1" (click)="action2()">{{ action2ButtonText }}</button>
   <button type="submit" class="btn btn-info" (click)="action1()" #submitButton>{{ action1ButtonText }}</button>
 </div>

--- a/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.ts
+++ b/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.ts
@@ -9,6 +9,8 @@ export class ChoiceModalComponent implements AfterViewInit {
   @Input() message: string;
   @Input() action1ButtonText: string;
   @Input() action2ButtonText: string;
+  @Input() action3ButtonText: string;
+  @Input() action3Disabled = false;
   @Input() cancelButtonText: string;
   @Input() question: string;
 
@@ -26,6 +28,10 @@ export class ChoiceModalComponent implements AfterViewInit {
 
   action2() {
     this.activeModal.close(2);
+  }
+
+  action3() {
+    this.activeModal.close(3);
   }
 
   cancel() {

--- a/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.ts
+++ b/src/app/views/sessions/session/dialogmodal/choicemodal/choice-modal.component.ts
@@ -8,7 +8,9 @@ export class ChoiceModalComponent implements AfterViewInit {
   @Input() title: string;
   @Input() message: string;
   @Input() action1ButtonText: string;
+  @Input() action1Disabled = false;
   @Input() action2ButtonText: string;
+  @Input() action2Disabled = false;
   @Input() action3ButtonText: string;
   @Input() action3Disabled = false;
   @Input() cancelButtonText: string;

--- a/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
+++ b/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
@@ -113,13 +113,15 @@ export class DialogModalService {
     return observableFrom(modalRef.result);
   }
 
-  openChoiceModal(title, message, question, action1ButtonText, action2ButtonText, cancelButtonText, action3?: { text: string; disabled?: boolean }) {
+  openChoiceModal(title, message, question, action1: { text: string; disabled?: boolean }, action2: { text: string; disabled?: boolean }, cancelButtonText: string, action3?: { text: string; disabled?: boolean }) {
     const modalRef = this.modalService.open(ChoiceModalComponent, { size: "lg" });
     modalRef.componentInstance.title = title;
     modalRef.componentInstance.message = message;
     modalRef.componentInstance.question = question;
-    modalRef.componentInstance.action1ButtonText = action1ButtonText;
-    modalRef.componentInstance.action2ButtonText = action2ButtonText;
+    modalRef.componentInstance.action1ButtonText = action1.text;
+    modalRef.componentInstance.action1Disabled = action1.disabled ?? false;
+    modalRef.componentInstance.action2ButtonText = action2.text;
+    modalRef.componentInstance.action2Disabled = action2.disabled ?? false;
     modalRef.componentInstance.cancelButtonText = cancelButtonText;
     if (action3) {
       modalRef.componentInstance.action3ButtonText = action3.text;

--- a/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
+++ b/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
@@ -113,14 +113,18 @@ export class DialogModalService {
     return observableFrom(modalRef.result);
   }
 
-  openChoiceModal(title, message, question, action1ButtonText, action2ButtonText, cancelButtonText) {
-    const modalRef = this.modalService.open(ChoiceModalComponent);
+  openChoiceModal(title, message, question, action1ButtonText, action2ButtonText, cancelButtonText, action3?: { text: string; disabled?: boolean }) {
+    const modalRef = this.modalService.open(ChoiceModalComponent, { size: "lg" });
     modalRef.componentInstance.title = title;
     modalRef.componentInstance.message = message;
     modalRef.componentInstance.question = question;
     modalRef.componentInstance.action1ButtonText = action1ButtonText;
     modalRef.componentInstance.action2ButtonText = action2ButtonText;
     modalRef.componentInstance.cancelButtonText = cancelButtonText;
+    if (action3) {
+      modalRef.componentInstance.action3ButtonText = action3.text;
+      modalRef.componentInstance.action3Disabled = action3.disabled ?? false;
+    }
     return modalRef.result;
   }
 

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.html
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.html
@@ -10,11 +10,11 @@
       </div>
 
       <div *ngIf="groupColumnMissing" class="alert alert-info p-0 mb-2">
-        <i class="fas fa-fw fa-exclamation-circle"></i>
+        <i class="fas fa-fw fa-exclamation-circle me-1"></i>
         <span class="font-italic">Group column is missing</span>
       </div>
       <div *ngIf="!phenodataFilled && !groupColumnMissing" class="alert alert-warning p-0 mb-2">
-        <i class="fas fa-fw fa-exclamation-circle"></i>
+        <i class="fas fa-fw fa-exclamation-circle me-1"></i>
         <span class="font-italic">Group column contains empty values</span>
       </div>
     </div>

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.html
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.html
@@ -6,7 +6,7 @@
           <i class="fas fa-plus"></i>
           Add column
         </button>
-        <button class="btn btn-sm btn-secondary float-end" (click)="reset()" [disabled]="!hasEditableColumns">Clear</button>
+        <button class="btn btn-sm btn-secondary float-end" (click)="reset()" [disabled]="!canReset">Reset</button>
       </div>
 
       <div *ngIf="groupColumnMissing" class="alert alert-info p-0 mb-2">

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -58,6 +58,13 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
     return this.headers.some((h) => !this.unremovableColumns.includes(h));
   }
 
+  get hasEditableValues(): boolean {
+    const editableIndices = this.headers
+      .map((h, i) => (this.unremovableColumns.includes(h) ? -1 : i))
+      .filter((i) => i !== -1);
+    return this.rows.some((row) => editableIndices.some((i) => row[i] != null && row[i] !== ""));
+  }
+
   get canReset(): boolean {
     return this.hasEditableColumns || (this.originalPhenodataString != null && this.originalPhenodataString !== this.phenodataString);
   }
@@ -274,8 +281,8 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
         "Reset phenodata",
         "You can clear the values in editable columns, delete all editable columns, or reset the phenodata to the state it was in when you opened this view.",
         "What would you like to do?",
-        "Delete columns",
-        "Clear values",
+        { text: "Delete columns", disabled: !this.hasEditableColumns },
+        { text: "Clear values", disabled: !this.hasEditableValues },
         "Cancel",
         { text: "Reset to previous", disabled: this.originalPhenodataString === this.phenodataString },
       )

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -41,15 +41,15 @@ export enum PhenodataState {
   encapsulation: ViewEncapsulation.None,
 })
 export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
-  @Input() private dataset: Dataset;
-  @Input() private datasetsMap: Map<string, Dataset>;
+  @Input() private dataset!: Dataset;
+  @Input() private datasetsMap!: Map<string, Dataset>;
 
   // MUST be handled outside Angular zone to prevent a change detection loop
-  hot;
-  rows: Array<Array<string>>;
-  headers: string[];
-  latestEdit: number;
-  deferredUpdatesTimerId: number | null = null;
+  hot: any;
+  rows: Array<Array<string>> = [];
+  headers: string[] = [];
+  latestEdit = 0;
+  deferredUpdatesTimerId: number | undefined = undefined;
   unremovableColumns = ["sample", "original_name"];
   private originalPhenodataString: string | null = null;
   private originalDatasetId: string | null = null;
@@ -63,14 +63,14 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
   }
   PhenodataState = PhenodataState; // for using the enum in template
   phenodataState: PhenodataState = PhenodataState.DATASET_NULL;
-  phenodataAncestor: Dataset;
+  phenodataAncestor: Dataset | null = null;
   phenodataFilled = false;
   groupColumnMissing = false;
   ready = false;
-  sortColumn: number;
-  sortOrder: boolean;
-  sortingEnabled: boolean;
-  phenodataString: string;
+  sortColumn: number | null = null;
+  sortOrder: boolean | null = null;
+  sortingEnabled = false;
+  phenodataString = "";
 
   private unsubscribe: Subject<any> = new Subject();
 
@@ -111,6 +111,9 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
           // don't update selectedDatasets at the moment
           // in this case, could use the one from the event also?
           const updatedDataset = this.datasetsMap.get(this.dataset.datasetId);
+          if (updatedDataset == null) {
+            return;
+          }
 
           if (this.datasetService.getOwnPhenodata(updatedDataset) === this.phenodataString) {
             return;
@@ -158,7 +161,9 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
 
   private updateSize(array: string[][], headers: string[]) {
     const container = document.getElementById("tableContainer");
-
+    if (!container) {
+      return;
+    }
     container.style.width = this.getWidth(array, headers) + "px";
     container.style.height = this.getHeight(array) + "px";
   }
@@ -308,17 +313,9 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
   }
 
   private updateDataset() {
-    const phenodataString: string = [this.headers].concat(this.rows).reduce(
-      (result: string, row: Array<string>) =>
-        (result +=
-          row
-            .reduce((rowString: string, cellValue: string) => {
-              const cellString = cellValue != null ? cellValue : "";
-              return rowString + cellString + "\t";
-            }, "")
-            .slice(0, -1) + "\n"),
-      "",
-    );
+    const phenodataString = [this.headers, ...this.rows]
+      .map((row) => row.map((cell) => cell ?? "").join("\t"))
+      .join("\n") + "\n";
 
     this.phenodataString = phenodataString;
 
@@ -379,12 +376,13 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
     }
     // get the latest datasets from the sessionData, because websocket events
     // don't update selectedDatasets at the moment
-    this.dataset = this.datasetsMap.get(this.dataset.datasetId);
-    if (this.dataset == null) {
+    const updatedDataset = this.datasetsMap.get(this.dataset.datasetId);
+    if (updatedDataset == null) {
       this.phenodataState = PhenodataState.DATASET_NULL;
       this.ready = true;
       return;
     }
+    this.dataset = updatedDataset;
 
     // find phenodata for this dataset, could be own or inherited
     let phenodataString;
@@ -444,7 +442,7 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
   private updateViewLater() {
     if (!this.isEditingNow()) {
       this.updateViewAfterDelay();
-    } else {
+    } else if (this.deferredUpdatesTimerId == null) {
       /*
        Defer updates when the table is being edited
 
@@ -464,16 +462,13 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
        so that we could recognize the events that we have create ourselves and wouldn't have
        to apply them to the table.
        */
-
-      if (this.deferredUpdatesTimerId == null) {
-        this.deferredUpdatesTimerId = window.setInterval(() => {
-          if (!this.isEditingNow()) {
-            window.clearInterval(this.deferredUpdatesTimerId);
-            this.deferredUpdatesTimerId = null;
-            this.updateViewAfterDelay();
-          }
-        }, 100);
-      }
+      this.deferredUpdatesTimerId = window.setInterval(() => {
+        if (!this.isEditingNow()) {
+          window.clearInterval(this.deferredUpdatesTimerId);
+          this.deferredUpdatesTimerId = undefined;
+          this.updateViewAfterDelay();
+        }
+      }, 100);
     }
   }
 

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -51,9 +51,15 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
   latestEdit: number;
   deferredUpdatesTimerId: number | null = null;
   unremovableColumns = ["sample", "original_name"];
+  private originalPhenodataString: string | null = null;
+  private originalDatasetId: string | null = null;
 
   get hasEditableColumns(): boolean {
     return this.headers.some((h) => !this.unremovableColumns.includes(h));
+  }
+
+  get canReset(): boolean {
+    return this.hasEditableColumns || (this.originalPhenodataString != null && this.originalPhenodataString !== this.phenodataString);
   }
   PhenodataState = PhenodataState; // for using the enum in template
   phenodataState: PhenodataState = PhenodataState.DATASET_NULL;
@@ -260,12 +266,13 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
     }
     this.stringModalService
       .openChoiceModal(
-        "Clear phenodata",
-        "Editable columns can be cleared of their values, or deleted entirely.",
-        "Would you like to clear the values or delete the columns?",
+        "Reset phenodata",
+        "You can clear the values in editable columns, delete all editable columns, or reset the phenodata to the state it was in when you opened this view.",
+        "What would you like to do?",
         "Delete columns",
         "Clear values",
         "Cancel",
+        { text: "Reset to previous", disabled: this.originalPhenodataString === this.phenodataString },
       )
       .then((action: number) => {
         if (action === 1) {
@@ -288,6 +295,14 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
           this.updateDataset();
           this.updateViewAfterDelay();
           this.zone.run(() => this.updateWarnings());
+        } else if (action === 3 && this.originalPhenodataString != null) {
+          this.datasetService.setPhenodata(this.dataset, this.originalPhenodataString);
+          this.phenodataString = this.originalPhenodataString;
+          this.sessionDataService.updateDataset(this.dataset).subscribe(
+            () => log.info("dataset phenodata updated"),
+            (err) => this.restErrorService.showError("dataset phenodata update failed", err),
+          );
+          this.updateViewAfterDelay();
         }
       }, () => {});
   }
@@ -376,6 +391,11 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
     if (this.datasetService.hasOwnPhenodata(this.dataset)) {
       phenodataString = this.datasetService.getOwnPhenodata(this.dataset);
       this.phenodataState = PhenodataState.OWN_PHENODATA;
+      if (this.dataset.datasetId !== this.originalDatasetId) {
+        this.originalDatasetId = this.dataset.datasetId;
+        this.originalPhenodataString = phenodataString;
+      }
+      this.phenodataString = phenodataString;
       this.phenodataFilled = this.datasetService.isPhenodataFilled(this.dataset);
       this.groupColumnMissing = !this.datasetService.hasGroupColumn(this.dataset);
     } else {

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -96,8 +96,8 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
     this.sessionEventService
       .getDatasetStream()
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(
-        (event) => {
+      .subscribe({
+        next: (event) => {
           // TODO if phenodata view starts to use fields other than the phenodata (such as name) and needs to react
           // to updates of those fields, add needed changes below. Now event stream causes update only if phenodata
           // has been changed
@@ -119,8 +119,8 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
           // someone else has changed phenodata, update
           this.updateViewLater();
         },
-        (err) => this.errorService.showError("phenodata update failed", err),
-      );
+        error: (err) => this.errorService.showError("phenodata update failed", err),
+      });
   }
 
   ngAfterViewInit() {
@@ -298,10 +298,10 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
         } else if (action === 3 && this.originalPhenodataString != null) {
           this.datasetService.setPhenodata(this.dataset, this.originalPhenodataString);
           this.phenodataString = this.originalPhenodataString;
-          this.sessionDataService.updateDataset(this.dataset).subscribe(
-            () => log.info("dataset phenodata updated"),
-            (err) => this.restErrorService.showError("dataset phenodata update failed", err),
-          );
+          this.sessionDataService.updateDataset(this.dataset).subscribe({
+            next: () => log.info("dataset phenodata updated"),
+            error: (err) => this.restErrorService.showError("dataset phenodata update failed", err),
+          });
           this.updateViewAfterDelay();
         }
       }, () => {});
@@ -324,10 +324,10 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
 
     if (phenodataString !== this.datasetService.getOwnPhenodata(this.dataset)) {
       this.datasetService.setPhenodata(this.dataset, phenodataString);
-      this.sessionDataService.updateDataset(this.dataset).subscribe(
-        () => log.info("dataset phenodata updated"),
-        (err) => this.restErrorService.showError("dataset phenodata update failed", err),
-      );
+      this.sessionDataService.updateDataset(this.dataset).subscribe({
+        next: () => log.info("dataset phenodata updated"),
+        error: (err) => this.restErrorService.showError("dataset phenodata update failed", err),
+      });
     }
   }
 
@@ -500,6 +500,6 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
           this.updateWarnings();
         }),
       )
-      .subscribe(null, (err) => this.restErrorService.showError("Add column failed", err));
+      .subscribe({ error: (err) => this.restErrorService.showError("Add column failed", err) });
   }
 }

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -266,7 +266,7 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
    *
    */
   reset() {
-    if (!this.hasEditableColumns) {
+    if (!this.canReset) {
       return;
     }
     this.stringModalService


### PR DESCRIPTION
## Summary

- Capture the phenodata when a dataset is first opened, and offer a **Reset to previous** option in the phenodata Reset dialog that restores it to that state
- The new option is disabled in the dialog when no changes have been made
- Rename the **Clear** button to **Reset** and update the dialog title and message accordingly
- Extend `ChoiceModalComponent` with optional third action button (text + disabled state) and open it at `size: lg` so all buttons fit on one row
- Convert deprecated positional `subscribe(next, error)` calls in the phenodata component to the observer-object form
- Clean up type and lint errors in `phenodata-visualization.component.ts` (initializers for fields, null-safety for `Map.get()` and `document.getElementById()`, `map`/`join`-based phenodata serialization)

## Test plan

- [ ] Open a dataset with phenodata, edit cells / delete columns, then click **Reset** — the dialog shows three buttons (**Reset to previous**, **Clear values**, **Delete columns**), all on one row
- [ ] Choose **Reset to previous** — phenodata returns to the state it was in when the view was opened
- [ ] Open the dialog with no changes — **Reset to previous** is disabled
- [ ] Navigate to another dataset and back — a fresh "previous" is captured
- [ ] Verify other dialog actions (**Delete columns**, **Clear values**) still behave correctly