### PR TITLE
UI text consistency: sentence case, ellipsis, typo fix

### DIFF
--- a/src/app/views/login/login.component.html
+++ b/src/app/views/login/login.component.html
@@ -56,7 +56,7 @@
           <div *ngIf="multipleLoginMethods" class="mt-4 text-smaller">
             <button class="btn btn-link" (click)="backToAuthSelect()">
               <!-- <i class="fa fa-arrow-left" aria-hidden="true"></i> -->
-              Select an other authentication method
+              Select another authentication method
             </button>
           </div>
         </div>

--- a/src/app/views/sessions/open-session-file/import-session-modal.component.html
+++ b/src/app/views/sessions/open-session-file/import-session-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">Import Sessions</h4>
+  <h4 class="modal-title">Import sessions</h4>
   <button type="button" class="btn-close" aria-label="Close" (click)="activeModal.close()"></button>
 </div>
 

--- a/src/app/views/sessions/session/samples-modal/samples-modal.component.html
+++ b/src/app/views/sessions/session/samples-modal/samples-modal.component.html
@@ -21,7 +21,7 @@
         </form>
       </div>
       <div class="col align-self-end">
-        <button type="button" (click)="onResetAll()" class="btn btn-sm btn-secondary ms-2 float-end">Reset All</button>
+        <button type="button" (click)="onResetAll()" class="btn btn-sm btn-secondary ms-2 float-end">Reset all</button>
       </div>
     </div>
 
@@ -32,7 +32,7 @@
         [disabled]="!singleTokenForm.valid"
         class="btn btn-sm btn-success"
         (click)="onFindSingle()">
-        One File per Sample
+        One file per sample
       </button>
     </div>
 
@@ -64,7 +64,7 @@
               id="r2TokenInput" />
           </div>
           <div class="col align-self-end float-end">
-            <button type="submit" [disabled]="!identifiersForm.valid" class="btn btn-sm btn-success">Find Pairs</button>
+            <button type="submit" [disabled]="!identifiersForm.valid" class="btn btn-sm btn-success">Find pairs</button>
           </div>
         </div>
       </div>
@@ -75,7 +75,7 @@
       <div>
         <span class="text-sm">{{ unpairedFiles.length }} undefined file{{ getPluralEnd(unpairedFiles.length) }}</span>
         <button (click)="onResetAll()" class="btn btn-sm btn-secondary float-end invisible mb-1">
-          Reset Everything
+          Reset everything
         </button>
       </div>
       <hr class="mt-1 mb-1" />

--- a/src/app/views/sessions/session/samples-modal/samples-modal.component.html
+++ b/src/app/views/sessions/session/samples-modal/samples-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">Define Sample Files</h4>
+  <h4 class="modal-title">Define sample files</h4>
   <button type="button" class="btn-close" aria-label="Close" (click)="activeModal.close()"></button>
 </div>
 

--- a/src/app/views/sessions/session/selectiondetails/job/job.component.html
+++ b/src/app/views/sessions/session/selectiondetails/job/job.component.html
@@ -1,4 +1,4 @@
-<h3 class="h3-xs mt-4">Job Details</h3>
+<h3 class="h3-xs mt-4">Job details</h3>
 <div *ngIf="!job" class="fst-italic text-smaller">Select job to see details</div>
 
 <div *ngIf="job">

--- a/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
+++ b/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
@@ -28,8 +28,8 @@
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="showJob()" [disabled]="sourceJob == null">Show job</button>
         <button ngbDropdownItem (click)="selectChildren()">Select descendants</button>
-        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session...</button>
-        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session...</button>
+        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session&hellip;</button>
+        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session&hellip;</button>
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="deleteDatasets()">Delete</button>
       </div>
@@ -58,8 +58,8 @@
       <div ngbDropdownMenu aria-labelledby="filesDropdownMenuButton">
         <button ngbDropdownItem (click)="defineDatasetGroups()">Define samples&hellip;</button>
         <button ngbDropdownItem (click)="selectChildren()">Select descendants</button>
-        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session...</button>
-        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session...</button>
+        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session&hellip;</button>
+        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session&hellip;</button>
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="deleteDatasets()">
           Delete {{ selectionService.selectedDatasets.length }} files

--- a/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
+++ b/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
@@ -27,7 +27,7 @@
         <button ngbDropdownItem (click)="showHistory()">History&hellip;</button>
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="showJob()" [disabled]="sourceJob == null">Show job</button>
-        <button ngbDropdownItem (click)="selectChildren()">Select all descendants</button>
+        <button ngbDropdownItem (click)="selectChildren()">Select descendants</button>
         <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session...</button>
         <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session...</button>
         <div class="dropdown-divider"></div>

--- a/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
+++ b/src/app/views/sessions/session/selectiondetails/selected-files/selected-files.component.html
@@ -21,15 +21,15 @@
       </button>
       <div ngbDropdownMenu aria-labelledby="fileDropdownMenuButton">
         <button ngbDropdownItem (click)="renameDataset()">Rename&hellip;</button>
-        <button ngbDropdownItem (click)="wrangleDataset()">Convert to Chipster Format&hellip;</button>
-        <button ngbDropdownItem (click)="defineDatasetGroups()">Define Samples&hellip;</button>
+        <button ngbDropdownItem (click)="wrangleDataset()">Convert to Chipster format&hellip;</button>
+        <button ngbDropdownItem (click)="defineDatasetGroups()">Define samples&hellip;</button>
         <button ngbDropdownItem (click)="exportDatasets()">Export</button>
         <button ngbDropdownItem (click)="showHistory()">History&hellip;</button>
         <div class="dropdown-divider"></div>
-        <button ngbDropdownItem (click)="showJob()" [disabled]="sourceJob == null">Show Job</button>
-        <button ngbDropdownItem (click)="selectChildren()">Select All Descendants</button>
-        <button ngbDropdownItem (click)="copyToNewSession()">Copy to a New Session...</button>
-        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to an Existing Session...</button>
+        <button ngbDropdownItem (click)="showJob()" [disabled]="sourceJob == null">Show job</button>
+        <button ngbDropdownItem (click)="selectChildren()">Select all descendants</button>
+        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session...</button>
+        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session...</button>
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="deleteDatasets()">Delete</button>
       </div>
@@ -56,10 +56,10 @@
         <i class="fas fa-lg fa-ellipsis-h" aria-hidden="true"></i>
       </button>
       <div ngbDropdownMenu aria-labelledby="filesDropdownMenuButton">
-        <button ngbDropdownItem (click)="defineDatasetGroups()">Define Samples&hellip;</button>
-        <button ngbDropdownItem (click)="selectChildren()">Select Descendants</button>
-        <button ngbDropdownItem (click)="copyToNewSession()">Copy to a New Session...</button>
-        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to an Existing Session...</button>
+        <button ngbDropdownItem (click)="defineDatasetGroups()">Define samples&hellip;</button>
+        <button ngbDropdownItem (click)="selectChildren()">Select descendants</button>
+        <button ngbDropdownItem (click)="copyToNewSession()">Copy to new session...</button>
+        <button ngbDropdownItem (click)="copyToExistingSession()">Copy to existing session...</button>
         <div class="dropdown-divider"></div>
         <button ngbDropdownItem (click)="deleteDatasets()">
           Delete {{ selectionService.selectedDatasets.length }} files

--- a/src/app/views/sessions/session/selectiondetails/singledataset/single-dataset.component.html
+++ b/src/app/views/sessions/session/selectiondetails/singledataset/single-dataset.component.html
@@ -21,8 +21,8 @@
                   <i class="fas fa-lg fa-ellipsis-h" aria-hidden="true"></i>
                 </button>
                 <div ngbDropdownMenu aria-labelledby="viewDropdownMenuButton">
-                  <button ngbDropdownItem (click)="selectTool()" [class.disabled]="!tool">Select Tool</button>
-                  <button ngbDropdownItem (click)="showJob()" [class.disabled]="!sourceJob">Show Job</button>
+                  <button ngbDropdownItem (click)="selectTool()" [class.disabled]="!tool">Select tool</button>
+                  <button ngbDropdownItem (click)="showJob()" [class.disabled]="!sourceJob">Show job</button>
                 </div>
               </div>
             </td>

--- a/src/app/views/sessions/session/session-details/session-details.component.html
+++ b/src/app/views/sessions/session/session-details/session-details.component.html
@@ -19,7 +19,7 @@
       </button>
       <div ngbDropdownMenu aria-labelledby="sessionDropdownMenuButton">
         <button ngbDropdownItem (click)="renameSessionModal()">Rename&hellip;</button>
-        <button ngbDropdownItem (click)="notesModal()">Edit Notes&hellip;</button>
+        <button ngbDropdownItem (click)="notesModal()">Edit notes&hellip;</button>
         <button ngbDropdownItem (click)="sharingModal()">Share&hellip;</button>
         <button ngbDropdownItem (click)="duplicateModal()">Duplicate&hellip;</button>
         <button ngbDropdownItem (click)="downloadSession()">Download&hellip;</button>

--- a/src/app/views/sessions/session/session-panel/session-panel.component.html
+++ b/src/app/views/sessions/session/session-panel/session-panel.component.html
@@ -37,7 +37,7 @@
               <div ngbDropdownMenu aria-labelledby="viewDropdownMenuButton">
                 <button ngbDropdownItem (click)="selectAll()">Select all files</button>
                 <button ngbDropdownItem (click)="selectChildren()" [class.disabled]="!isDatasetsSelected()">
-                  Select Descendants of Selected Files
+                  Select descendants of selected files
                 </button>
                 <div class="dropdown-divider"></div>
 

--- a/src/app/views/sessions/session/session-panel/upload/upload.component.html
+++ b/src/app/views/sessions/session/session-panel/upload/upload.component.html
@@ -16,6 +16,6 @@
     <button #uploadFolderButton ngbDropdownItem>Upload folder</button>
     <button ngbDropdownItem (click)="downloadFromUrl()">Download from URL</button>
     <div class="dropdown-divider"></div>
-    <button ngbDropdownItem (click)="mergeSession()">Merge Session</button>
+    <button ngbDropdownItem (click)="mergeSession()">Merge session</button>
   </div>
 </div>

--- a/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
+++ b/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
@@ -1519,7 +1519,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.convertMenuItem = {
-      title: "Convert to Chipster Format...",
+      title: "Convert to Chipster format...",
       action(d): void {
         self.datasetModalService.openWrangleModal(d.dataset, self.sessionData);
       },
@@ -1549,14 +1549,14 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.groupsMenuItem = {
-      title: "Define Samples...",
+      title: "Define samples...",
       action(): void {
         self.datasetModalService.openGroupsModal(self.selectedDatasets, self.sessionData);
       },
     };
 
     this.showJobMenuItem = {
-      title: "Show Job",
+      title: "Show job",
       action(d): void {
         self.datasetContextMenuService.showJob(self.selectedDatasetSourceJob, self.tools, self.sessionData);
       },
@@ -1566,7 +1566,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.selectChildrenMenuItem = {
-      title: "Select Descendants",
+      title: "Select descendants",
       action(): void {
         const children = self.getSessionDataService.getChildren(self.selectionService.selectedDatasets);
         self.selectionHandlerService.setDatasetSelection(children);
@@ -1574,7 +1574,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.copySelectedToNewSessionMenuItem = {
-      title: "Copy to a New Session",
+      title: "Copy to new session",
       action(d): void {
         let datasets = self.selectionService.selectedDatasets;
 
@@ -1588,7 +1588,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.copySelectedToExistingSessionMenuItem = {
-      title: "Copy to an Existing Session",
+      title: "Copy to existing session",
       action(d): void {
         let datasets = self.selectionService.selectedDatasets;
 

--- a/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
+++ b/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
@@ -1500,7 +1500,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     const self = this;
 
     this.renameMenuItem = {
-      title: "Rename...",
+      title: "Rename&hellip;",
       action(d): void {
         const dataset = clone(d.dataset);
         self.dialogModalService
@@ -1519,7 +1519,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.convertMenuItem = {
-      title: "Convert to Chipster format...",
+      title: "Convert to Chipster format&hellip;",
       action(d): void {
         self.datasetModalService.openWrangleModal(d.dataset, self.sessionData);
       },
@@ -1549,7 +1549,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.groupsMenuItem = {
-      title: "Define samples...",
+      title: "Define samples&hellip;",
       action(): void {
         self.datasetModalService.openGroupsModal(self.selectedDatasets, self.sessionData);
       },
@@ -1574,7 +1574,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.copySelectedToNewSessionMenuItem = {
-      title: "Copy to new session",
+      title: "Copy to new session&hellip;",
       action(d): void {
         let datasets = self.selectionService.selectedDatasets;
 
@@ -1588,7 +1588,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.copySelectedToExistingSessionMenuItem = {
-      title: "Copy to existing session",
+      title: "Copy to existing session&hellip;",
       action(d): void {
         let datasets = self.selectionService.selectedDatasets;
 
@@ -1609,7 +1609,7 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     };
 
     this.historyMenuItem = {
-      title: "History...",
+      title: "History&hellip;",
       action(d): void {
         self.datasetModalService.openDatasetHistoryModal(d.dataset, self.sessionData, self.tools);
       },

--- a/src/app/views/sessions/session/tools/tool-parameters/tool-parameters.component.html
+++ b/src/app/views/sessions/session/tools/tool-parameters/tool-parameters.component.html
@@ -21,7 +21,7 @@
         (click)="resetAll()"
         title="Reset all">
         <span class="fas fa-fw fa-undo text-primary" aria-hidden="true"></span>
-        Reset All
+        Reset all
       </button>
       <button
         *ngIf="!isResetAllVisible()"
@@ -30,7 +30,7 @@
         title="Reset all"
         [disabled]="true">
         <span class="fas fa-fw fa-undo" aria-hidden="true"></span>
-        Reset All
+        Reset all
       </button>
     </div>
   </div>

--- a/src/app/views/sessions/session/tools/tool-resources/tool-resources.component.html
+++ b/src/app/views/sessions/session/tools/tool-resources/tool-resources.component.html
@@ -21,7 +21,7 @@
         (click)="resetAll()"
         title="Reset all">
         <span class="fas fa-fw fa-undo text-primary" aria-hidden="true"></span>
-        Reset All
+        Reset all
       </button>
       <button
         *ngIf="!isResetAllVisible()"
@@ -30,7 +30,7 @@
         title="Reset all"
         [disabled]="true">
         <span class="fas fa-fw fa-undo" aria-hidden="true"></span>
-        Reset All
+        Reset all
       </button>
     </div>
   </div>

--- a/src/app/views/sessions/session/tools/tools.component.html
+++ b/src/app/views/sessions/session/tools/tools.component.html
@@ -204,14 +204,14 @@
                       ngbDropdownItem
                       (click)="runJob(false)"
                       [disabled]="!validatedTool.singleJobValidation.valid">
-                      Run Tool
+                      Run tool
                       <span *ngIf="validatedTool.singleJobValidation.valid" class="text-muted text-sm">1 job</span>
                     </button>
                     <button
                       ngbDropdownItem
                       (click)="runJob(true)"
                       [disabled]="!validatedTool.runForEachValidation.valid">
-                      Run Tool for Each File
+                      Run tool for each file
                       <span *ngIf="validatedTool.runForEachValidation.valid" class="text-muted text-sm">
                         {{ validatedTool.selectedDatasets.length }} jobs
                       </span>
@@ -220,7 +220,7 @@
                       ngbDropdownItem
                       (click)="runForEachSample()"
                       [disabled]="!validatedTool.runForEachSampleValidation.valid">
-                      Run Tool For Each Sample
+                      Run tool for each sample
                       <span *ngIf="validatedTool.runForEachSampleValidation.valid" class="text-muted text-sm">
                         {{
                           validatedTool.sampleGroups.pairedEndSamples.length +
@@ -235,7 +235,7 @@
                       ngbDropdownItem
                       (click)="onDefineSamples()"
                       [disabled]="validatedTool.runForEachSampleValidation.valid">
-                      Define Samples to Enable Run for Each Sample
+                      Define samples to enable run for each sample
                     </button>
                   </div>
                 </div>

--- a/src/app/views/terms/terms.component.html
+++ b/src/app/views/terms/terms.component.html
@@ -4,6 +4,6 @@
   </div>
 
   <div *ngIf="showAccept" class="text-center margin-top margin-bottom">
-    <button class="btn btn-primary" type="button" (click)="accept()">Accept Terms of Use</button>
+    <button class="btn btn-primary" type="button" (click)="accept()">Accept terms of use</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Sentence case for button labels, context menu/dropdown labels, and modal/section titles
- Drop articles in \"Copy to …\" menu entries; drop \"all\" from \"Select descendants\"
- Use `&hellip;` consistently for ellipsis in menu labels (was mixed `&hellip;` / `...`)
- Fix \"an other\" → \"another\" typo on login screen

Pure text/label changes — no logic touched.

## Test plan
- [ ] Dropdown menus render correctly in selected-files, single-dataset, session-details, session-panel, upload, tools panels
- [ ] d3 right-click context menu in workflow graph renders correctly (and ellipsis decoded via `.html()`)
- [ ] Modal titles correct: Import sessions, Define sample files
- [ ] Login screen "Select another authentication method" reads correctly