### PR TITLE
Phenodata column improvements: block edits, place group

### DIFF
--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.less
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.less
@@ -18,3 +18,7 @@
   overflow-x: scroll;
   overflow-y: hidden;
 }
+
+#tableContainer .htDimmed {
+  color: inherit;
+}

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -493,10 +493,15 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
         tap((name) => {
           this.zone.runOutsideAngular(() => {
             const colHeaders = (this.hot.getSettings() as ht.Options).colHeaders as Array<string>;
-            this.hot.alter("insert_col", colHeaders.length);
-            // remove undefined column header
-            colHeaders.pop();
-            colHeaders.push(name);
+            const lastNonEditableIdx = colHeaders.reduce(
+              (acc, h, i) => (this.nonEditableColumns.includes(h) ? i : acc),
+              -1,
+            );
+            const insertIndex =
+              name === this.datasetService.GROUP_COLUMN ? lastNonEditableIdx + 1 : colHeaders.length;
+            this.hot.alter("insert_col", insertIndex);
+            // Handsontable inserts an undefined entry at insertIndex; replace it with the name.
+            colHeaders[insertIndex] = name;
             this.hot.updateSettings(
               {
                 colHeaders,

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -50,17 +50,17 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
   headers: string[] = [];
   latestEdit = 0;
   deferredUpdatesTimerId: number | undefined = undefined;
-  unremovableColumns = ["sample", "original_name"];
+  nonEditableColumns = ["sample", "original_name"];
   private originalPhenodataString: string | null = null;
   private originalDatasetId: string | null = null;
 
   get hasEditableColumns(): boolean {
-    return this.headers.some((h) => !this.unremovableColumns.includes(h));
+    return this.headers.some((h) => !this.nonEditableColumns.includes(h));
   }
 
   get hasEditableValues(): boolean {
     const editableIndices = this.headers
-      .map((h, i) => (this.unremovableColumns.includes(h) ? -1 : i))
+      .map((h, i) => (this.nonEditableColumns.includes(h) ? -1 : i))
       .filter((i) => i !== -1);
     return this.rows.some((row) => editableIndices.some((i) => row[i] != null && row[i] !== ""));
   }
@@ -198,11 +198,18 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
       height: this.getHeight(array),
 
       afterGetColHeader: (col: number, TH: any) => {
-        if (this.unremovableColumns.includes(headers[col])) {
+        if (this.nonEditableColumns.includes(headers[col])) {
           // removal not allowed
           return;
         }
         this.createRemoveButton(col, TH);
+      },
+
+      cells: (_row: number, col: number) => {
+        if (this.nonEditableColumns.includes(headers[col])) {
+          return { readOnly: true };
+        }
+        return {};
       },
 
       afterChange: (changes: any, source: string) => {
@@ -289,7 +296,7 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
       .then((action: number) => {
         if (action === 1) {
           const keepIndices = this.headers
-            .map((h, i) => (this.unremovableColumns.includes(h) ? i : -1))
+            .map((h, i) => (this.nonEditableColumns.includes(h) ? i : -1))
             .filter((i) => i !== -1);
           this.headers = keepIndices.map((i) => this.headers[i]);
           this.rows = this.rows.map((row) => keepIndices.map((i) => row[i]));
@@ -297,7 +304,7 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
           this.updateViewAfterDelay();
         } else if (action === 2) {
           const removableIndices = this.headers
-            .map((h, i) => (this.unremovableColumns.includes(h) ? -1 : i))
+            .map((h, i) => (this.nonEditableColumns.includes(h) ? -1 : i))
             .filter((i) => i !== -1);
           this.rows.forEach((_row, rowIndex) => {
             removableIndices.forEach((colIndex) => {


### PR DESCRIPTION
## Summary
- Block cell edits in non-editable phenodata columns (`sample`, `original_name`): the column delete button was already hidden, but cell values themselves were still editable via double-click, paste, and autofill. Now Handsontable's `cells` callback marks those cells `readOnly: true`, which gates all mutation paths at the source. Also renames the underlying list from `unremovableColumns` → `nonEditableColumns` to reflect the broader semantics.
- When the user adds a column named `group` via the *Add column* modal, place it immediately after the non-editable columns instead of at the end of the table. Other column names continue to append at the end.

A small Less override (`#tableContainer .htDimmed { color: inherit; }`) keeps text in the read-only cells at the normal color — the data in those columns is essential and shouldn't look muted.

## Test plan
- [ ] `sample` and `original_name` cells display with normal text color (not muted)
- [ ] Double-click / type / paste / autofill into a `sample` or `original_name` cell is blocked
- [ ] Editing values in other columns still works (incl. paste and autofill)
- [ ] *Add column* with name `group` → column appears at index 2 (after `original_name`), not at the end
- [ ] *Add column* with any other name → column appears at the end (regression check)
- [ ] *Add column* with name `Group` (capital G) → appends at the end (case-sensitive, matches `hasGroupColumn` convention)
- [ ] Clear dialog still preserves `sample` and `original_name` as before