### PR TITLE
Close ng-bootstrap dropdowns on workflow-area click

### DIFF
--- a/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
+++ b/src/app/views/sessions/session/session-panel/workflow-graph/workflow-graph.component.ts
@@ -296,6 +296,87 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
         this.updateSvgSize();
       }
     }, 0);
+
+    // d3-drag (on the workflow background and on dataset rects) calls
+    // event.stopImmediatePropagation() on every mousedown AND on every
+    // mouseup (the mouseup listener is attached on window in capture phase),
+    // so ng-bootstrap's autoclose listeners on document never see workflow-
+    // area pointer events. The dropdown therefore stays open even when the
+    // user clearly clicks outside it.
+    //
+    // Work around it by re-dispatching synthetic mousedown/mouseup events on
+    // document.body (target outside any dropdown panel) so ng-bootstrap's
+    // existing autoclose logic fires. Mousedown is re-dispatched immediately
+    // (capture-phase listener on document fires before d3-drag's target-phase
+    // listener stops propagation). Mouseup is re-dispatched in the next
+    // microtask so d3-drag's window-capture mouseup listener has time to run
+    // and remove itself first — otherwise the synthetic mouseup would
+    // re-trigger d3-drag's "end" handler.
+    document.addEventListener("mousedown", this.reDispatchWorkflowMousedown, true);
+    window.addEventListener("mouseup", this.reDispatchWorkflowMouseup, true);
+  }
+
+  private workflowMousedownPending = false;
+
+  private readonly reDispatchWorkflowMousedown = (event: MouseEvent): void => {
+    if (this.isWorkflowMousedownReDispatch(event)) {
+      return;
+    }
+    const target = event.target as Element | null;
+    if (!target?.closest?.("#workflow-graph")) {
+      // Any non-workflow mousedown "consumes" the pending flag so it can't
+      // drift out of sync if a previous workflow mousedown never received
+      // a matching mouseup (e.g. user dragged off the browser window).
+      this.workflowMousedownPending = false;
+      return;
+    }
+    this.workflowMousedownPending = true;
+    const copy = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      button: event.button,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      view: window,
+    });
+    this.markWorkflowMousedownReDispatch(copy);
+    document.body.dispatchEvent(copy);
+  };
+
+  private readonly reDispatchWorkflowMouseup = (event: MouseEvent): void => {
+    if (!this.workflowMousedownPending) {
+      return;
+    }
+    if (this.isWorkflowMousedownReDispatch(event)) {
+      return;
+    }
+    this.workflowMousedownPending = false;
+    const button = event.button;
+    const clientX = event.clientX;
+    const clientY = event.clientY;
+    // Defer to next microtask so d3-drag's mouseupped (also on window, capture)
+    // finishes and removes its window listeners first; otherwise our synthetic
+    // mouseup would re-trigger d3-drag's "end" handler.
+    Promise.resolve().then(() => {
+      const copy = new MouseEvent("mouseup", {
+        bubbles: true,
+        cancelable: true,
+        button,
+        clientX,
+        clientY,
+        view: window,
+      });
+      this.markWorkflowMousedownReDispatch(copy);
+      document.body.dispatchEvent(copy);
+    });
+  };
+
+  private isWorkflowMousedownReDispatch(event: MouseEvent): boolean {
+    return (event as MouseEvent & { __workflowReDispatch?: boolean }).__workflowReDispatch === true;
+  }
+
+  private markWorkflowMousedownReDispatch(event: MouseEvent): void {
+    (event as MouseEvent & { __workflowReDispatch?: boolean }).__workflowReDispatch = true;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -328,6 +409,8 @@ export class WorkflowGraphComponent implements OnInit, OnChanges, OnDestroy {
     this.removeDatasetNodeToolTips();
     this.subscriptions.forEach((subs) => subs.unsubscribe());
     this.subscriptions = [];
+    document.removeEventListener("mousedown", this.reDispatchWorkflowMousedown, true);
+    window.removeEventListener("mouseup", this.reDispatchWorkflowMouseup, true);
   }
 
   zoomIn(): void {


### PR DESCRIPTION
## Summary

- Fixes a bug where opening any ng-bootstrap dropdown (e.g. the workflow Actions menu, per-file context menus) and then clicking on the workflow SVG area would leave the dropdown open. Clicks everywhere else on the page closed dropdowns correctly.
- Root cause: d3-drag's mousedown listener (on dataset/background rects) and mouseup listener (on `window`, capture phase) both call `event.stopImmediatePropagation()`, which prevents ng-bootstrap's document-level autoclose listeners from ever seeing workflow-area pointer events.
- Fix: re-dispatch synthetic mousedown/mouseup events on `document.body` for workflow-area clicks so ng-bootstrap's existing autoclose logic runs. Mousedown is forwarded immediately from a document capture-phase listener; mouseup is deferred a microtask so d3-drag's own window mouseup handler runs and removes itself first — otherwise our synthetic would re-trigger the drag `end` handler.

## Test plan

- [ ] Open the workflow toolbar Actions (⋯) menu, click on the workflow background → menu closes.
- [ ] Open the Actions menu, click on a dataset box → menu closes; dataset is (de)selected as before.
- [ ] Open the per-file context menu in the Selected Files panel, click on the workflow → menu closes.
- [ ] Rectangle drag-select on the workflow background still works and selects intersecting datasets.
- [ ] Dragging a selected dataset still moves it; no spurious selection toggle.
- [ ] Right-click on a dataset still opens the d3-context-menu.
- [ ] Other ng-bootstrap dropdowns/popovers/modals around the app still open and close normally.
- [ ] Switch between sessions a few times; no listener leaks (ngOnDestroy removes both listeners).