### PR TITLE
Fix empty space above Files/Tools when PDF viewer opens

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,20 @@
 /* You can add global styles to this file, and also import other style files */
 @import "bootstrap-custom";
 
+/*
+Custom element component hosts default to display:inline. Left inline, they share a single
+inline formatting context, which lets a heavy reflow elsewhere (e.g. the PDF viewer's
+dynamic height) stretch an earlier host's box and push the layout down. Make the structural
+shell hosts block-level so each owns an independent box.
+*/
+ch-app-root,
+ch-navigation,
+ch-hotkey-cheatsheet,
+ch-error,
+ch-session {
+  display: block;
+}
+
 // allow absolute positioning inside the search field
 .tab-form-container {
   position: relative;


### PR DESCRIPTION
## Problem

When a PDF file is selected, the PDF viewer opens in the visualization panel and a block of empty vertical space appears between the navigation bar and the "Files" / "Tools" panel titles. The gap is PDF-specific and disappears when switching to another file type.

## Root cause

The shell component hosts (`ch-app-root`, `ch-navigation`, `ch-hotkey-cheatsheet`, `ch-error`, `ch-session`) had no `display` rule, so they defaulted to `display: inline` and shared a single inline formatting context. The PDF viewer's reflow (its dynamically computed host height plus the absolutely-positioned container and the `min-height: 100vh` panel) stretched the `<ch-navigation>` host's box within that shared context, pushing the layout down.

DevTools confirmed the extra height lived inside the `<ch-navigation>` host box itself (below the `<nav>`), only while a PDF rendered.

## Fix

Make the structural shell hosts block-level so each owns an independent box and can no longer be stretched by a sibling reflow.

## Testing

- Verified the gap is gone with a PDF open; PDF zoom / page navigation / show-all still work.
- Confirmed `ch-navigation` height now equals the `<nav>` height.
- Switched between PDF and non-PDF visualizations (Text, Image) — no gap either way, scroll position preserved.
- Spot-checked non-session pages (home, login, sessions list, manual, admin) — no spacing regressions.