### PR TITLE
Surface backend reason for 400 Bad Request responses

### DIFF
--- a/src/app/core/errorhandler/rest-error.service.spec.ts
+++ b/src/app/core/errorhandler/rest-error.service.spec.ts
@@ -1,0 +1,72 @@
+import { HttpErrorResponse } from "@angular/common/http";
+import { ErrorMessage } from "./errormessage";
+import { ErrorService } from "./error.service";
+import { RestErrorService } from "./rest-error.service";
+
+describe("RestErrorService", () => {
+  let service: RestErrorService;
+  let shown: ErrorMessage | null;
+
+  beforeEach(() => {
+    shown = null;
+    const errorServiceStub = {
+      showErrorObject: (errorMessage: ErrorMessage) => {
+        shown = errorMessage;
+      },
+    } as unknown as ErrorService;
+    service = new RestErrorService(errorServiceStub);
+  });
+
+  describe("showError with a 400 Bad Request", () => {
+    it("surfaces a plain-text reason in resp.error", () => {
+      const resp = new HttpErrorResponse({
+        status: 400,
+        error: "session has reached the maximum of 100 labels",
+      });
+
+      service.showError("Copy selection failed", resp);
+
+      expect(shown.title).toBe("Copy selection failed");
+      expect(shown.msg).toBe("session has reached the maximum of 100 labels");
+    });
+
+    it("surfaces a reason wrapped in resp.error.text (failed JSON parse)", () => {
+      const resp = new HttpErrorResponse({
+        status: 400,
+        error: { error: new SyntaxError("bad json"), text: "session has reached the maximum of 100 labels" },
+      });
+
+      service.showError("Copy selection failed", resp);
+
+      expect(shown.title).toBe("Copy selection failed");
+      expect(shown.msg).toBe("session has reached the maximum of 100 labels");
+    });
+
+    it("falls back to 'Bad request' when the body is empty", () => {
+      const resp = new HttpErrorResponse({ status: 400, error: "   " });
+
+      service.showError("Copy selection failed", resp);
+
+      expect(shown.title).toBe("Copy selection failed");
+      expect(shown.msg).toBe("Bad request");
+    });
+  });
+
+  describe("showError with other statuses", () => {
+    it("keeps the existing 'Not found' title for a 404", () => {
+      const resp = new HttpErrorResponse({ status: 404, error: "missing" });
+
+      service.showError("Loading failed", resp);
+
+      expect(shown.title).toBe("Not found");
+    });
+
+    it("keeps the existing 'Authentication failed' title for a 403", () => {
+      const resp = new HttpErrorResponse({ status: 403, error: "forbidden" });
+
+      service.showError("Loading failed", resp);
+
+      expect(shown.title).toBe("Authentication failed");
+    });
+  });
+});

--- a/src/app/core/errorhandler/rest-error.service.ts
+++ b/src/app/core/errorhandler/rest-error.service.ts
@@ -18,6 +18,10 @@ export class RestErrorService {
     return RestErrorService.isHttpError(error, 429);
   }
 
+  static isBadRequest(error: HttpErrorResponse | any) {
+    return RestErrorService.isHttpError(error, 400);
+  }
+
   static isHttpError(error: HttpErrorResponse | any, status: number) {
     return (error instanceof HttpErrorResponse || error instanceof Response) && error.status === status;
   }
@@ -72,12 +76,33 @@ export class RestErrorService {
       errorMessage.title = message;
       errorMessage.msg = this.getTooManyRequestsMessage(resp);
       errorMessage.buttons = [ErrorButton.ContactSupport];
+    } else if (RestErrorService.isBadRequest(resp)) {
+      // surface the backend's plain-text reason (e.g. "session has reached the
+      // maximum of 100 labels") so the user knows what to fix; Reload won't help
+      const reason = this.getServerErrorMessage(resp);
+      errorMessage.title = message;
+      errorMessage.msg = reason ?? "Bad request";
+      errorMessage.buttons = [ErrorButton.ContactSupport];
     }
 
     this.errorService.showErrorObject(errorMessage);
 
     // log
     log.info("rest error handled", message, resp);
+  }
+
+  /**
+   * Extract the server's error body as plain text, or null if there's none.
+   *
+   * The backend sends error details as text/plain (see BadRequestExceptionMapper),
+   * but the requests use Angular's default responseType "json", so a non-JSON body
+   * lands either directly in resp.error (string) or wrapped as resp.error.text after
+   * a failed JSON parse. Handle both.
+   */
+  private getServerErrorMessage(resp: any): string | null {
+    const body = typeof resp?.error === "string" ? resp.error : resp?.error?.text;
+    const trimmed = typeof body === "string" ? body.trim() : "";
+    return trimmed.length > 0 ? trimmed : null;
   }
 
   getTooManyRequestsMessage(resp) {


### PR DESCRIPTION
## What

Show the server's plain-text error body in the error dialog for HTTP 400 responses, so the user sees what to fix instead of a generic message. Example: *"session has reached the maximum of 100 labels"*. The Reload button is dropped for 400s, since reloading won't help a bad request.

## Why

The backend sends 400 error details as `text/plain` (via `BadRequestExceptionMapper`), but until now the frontend discarded that body and showed only a generic error. 24 backend endpoints throw `BadRequestException` with a useful message — those reasons are now surfaced to the user.

## How

- Add `RestErrorService.isBadRequest` and a 400 branch in `showError`, mirroring the existing 429 handling.
- Extract the body with a new `getServerErrorMessage` helper that handles both shapes: the body lands directly in `resp.error` when the response is text, or wrapped as `resp.error.text` after a failed JSON parse with the default `responseType: "json"`. Falls back to "Bad request" when the body is empty.

## Scope

This is a generic, app-wide error-handling change (not tied to any single feature) and touches only `RestErrorService`. Split out from the labels work since it stands on its own and is exercised by existing 400-returning endpoints today.

## Testing

Added `rest-error.service.spec.ts` covering both body shapes, the empty-body fallback, and that 403/404 handling is unchanged.

Manual: open a session → Share → add a rule with a whitespace-only UserID → the dialog now shows the backend reason ("invalid userId").