### PR TITLE
Prevent sharing a session to a blank username

### DIFF
--- a/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.html
+++ b/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.html
@@ -42,7 +42,11 @@
       </tr>
       <tr *ngIf="newRule">
         <th scope="row">
-          <input #usernameInput type="text" [(ngModel)]="newRule.username" (keyup.enter)="saveRule()" />
+          <input
+            #usernameInput
+            type="text"
+            [(ngModel)]="newRule.username"
+            (keyup.enter)="!isNewRuleUsernameBlank() && saveRule()" />
         </th>
         <td>
           <select [(ngModel)]="newRule.readWrite">
@@ -60,7 +64,7 @@
 
   <div *ngIf="newRule">
     <button class="btn btn-sm btn-secondary me-1" (click)="newRule = null">Cancel</button>
-    <button class="btn btn-sm btn-success" (click)="saveRule()">Save</button>
+    <button class="btn btn-sm btn-success" [disabled]="isNewRuleUsernameBlank()" (click)="saveRule()">Add</button>
   </div>
 
   <br />

--- a/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.ts
+++ b/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.ts
@@ -72,6 +72,9 @@ export class SharingModalComponent implements AfterViewInit, OnInit, OnDestroy {
   }
 
   saveRule() {
+    if (this.isNewRuleUsernameBlank()) {
+      return;
+    }
     this.newRule.username = this.newRule.username.trim();
     this.sessionResource.createRule(this.session.sessionId, this.newRule).subscribe(
       (resp) => {
@@ -98,6 +101,10 @@ export class SharingModalComponent implements AfterViewInit, OnInit, OnDestroy {
 
   getUsername() {
     return this.tokenService.getUsername();
+  }
+
+  isNewRuleUsernameBlank() {
+    return !this.newRule?.username?.trim();
   }
 
   isDeleteEnabled(rule: Rule) {


### PR DESCRIPTION
## What

The share-session dialog let the user submit an empty or whitespace-only UserID. The request went to the backend, which rejected it with a 400. This disables the Add button (and ignores Enter) while the username is blank, so the invalid request is never made.

## Why

- A blank UserID is never a valid share target, so it shouldn't be submittable.
- It also fixes a latent crash: `saveRule()` called `username.trim()` on an `undefined` username (Add rule → Enter with nothing typed), throwing a `TypeError`.

## How

- Add `isNewRuleUsernameBlank()`, null/empty/whitespace-safe (`!this.newRule?.username?.trim()`).
- Disable the button with `[disabled]` and gate the `keyup.enter` handler on the same check (the disabled button doesn't block Enter on its own).
- Guard `saveRule()` to early-return when blank, so the method is self-protecting regardless of caller.
- Rename the button from "Save" to "Add".

## Testing

Manual: open a session → Share → Add rule. The Add button stays disabled until a non-blank UserID is entered; Enter does nothing while blank. A valid UserID still creates the rule as before.