### PR TITLE
Use airbnb-typescript/base ESLint config for Angular

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
       "extends": [
         "eslint:recommended",
         "airbnb-base",
-        "airbnb-typescript",
+        "airbnb-typescript/base",
         "plugin:import/recommended",
         "plugin:import/typescript",
         "plugin:@angular-eslint/recommended",


### PR DESCRIPTION
## Problem

Linting any `.ts` file produced a spurious error on every file:

```
1:1  error  Definition for rule 'react/jsx-filename-extension' was not found  react/jsx-filename-extension
```

The `.eslintrc.json` extended the full `airbnb-typescript` config, which is the **React** variant — it enables rules like `react/jsx-filename-extension` and assumes `eslint-plugin-react` is installed. This is an Angular project, so that plugin is absent.

## Fix

Switch to the non-React variant `airbnb-typescript/base`, which pairs with `airbnb-base` and keeps the TypeScript overrides while dropping the React rules.

## Effect

`npm run lint` over `src/app/` goes from **788 problems (758 errors)** to **531 problems (501 errors)** — the ~257 removed are one bogus `react/jsx-filename-extension` error per `.ts` file. The remaining 501 errors are a pre-existing backlog, unaffected by this change.