### PR TITLE
Add column titles to multi-file details table

### DIFF
--- a/src/app/views/sessions/session/selectiondetails/files-details.component.ts/files-details.component.html
+++ b/src/app/views/sessions/session/selectiondetails/files-details.component.ts/files-details.component.html
@@ -1,5 +1,12 @@
 <div class="dataset-details">
   <table class="table table-sm table-borderless align-top">
+    <thead>
+      <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Size</th>
+        <th *ngIf="showDate" scope="col">Date</th>
+      </tr>
+    </thead>
     <tbody>
       <tr *ngFor="let dataset of datasets">
         <td class="">{{ dataset.name }}</td>


### PR DESCRIPTION
## Summary

In the Details tab of the visualization panel, when more than one file is selected, a table lists the selected files with name, size and creation date. The table had no header row, leaving the columns unlabeled.

This adds a `<thead>` with column titles (Name, Size, Date) to the `ch-files-details` component. The Date header uses the same `*ngIf="showDate"` guard as its body cell, so it appears and hides together with the Date column. No TypeScript or styling changes were needed — Bootstrap's `table` class styles the header automatically.

## Test plan

- Open a session, select two or more files, and open the Details tab.
- Confirm the table shows the column titles (Name, Size, Date) above the rows.
- Confirm the Date title hides together with the Date column when `showDate` is false.