### PR TITLE
Use danger styling for delete confirmation buttons

### DIFF
--- a/src/app/views/sessions/session-list.component.ts
+++ b/src/app/views/sessions/session-list.component.ts
@@ -471,7 +471,7 @@ export class SessionListComponent implements OnInit, OnDestroy {
 
   deleteSession(session: Session) {
     this.dialogModalService
-      .openBooleanModal("Delete session", "Delete session " + session.name + "?", "Delete", "Cancel")
+      .openBooleanModal("Delete session", "Delete session " + session.name + "?", "Delete", "Cancel", "btn-danger")
       .then(
         () => {
           if (this.selectedSession === session) {

--- a/src/app/views/sessions/session/dialogmodal/booleanmodal/booleanmodal.component.html
+++ b/src/app/views/sessions/session/dialogmodal/booleanmodal/booleanmodal.component.html
@@ -8,5 +8,5 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary float-end" (click)="cancel()">{{ cancelButtonText }}</button>
-  <button type="submit" class="btn btn-info" (click)="save()" #submitButton>{{ okButtonText }}</button>
+  <button type="submit" class="btn {{ okButtonClass }}" (click)="save()" #submitButton>{{ okButtonText }}</button>
 </div>

--- a/src/app/views/sessions/session/dialogmodal/booleanmodal/booleanmodal.component.ts
+++ b/src/app/views/sessions/session/dialogmodal/booleanmodal/booleanmodal.component.ts
@@ -8,6 +8,8 @@ export class BooleanModalComponent implements AfterViewInit {
   @Input()
   okButtonText: string;
   @Input()
+  okButtonClass: string = "btn-info";
+  @Input()
   cancelButtonText: string;
   @Input()
   message: string;

--- a/src/app/views/sessions/session/dialogmodal/delete-files-modal/delete-files-modal.component.html
+++ b/src/app/views/sessions/session/dialogmodal/delete-files-modal/delete-files-modal.component.html
@@ -22,5 +22,5 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary float-end" (click)="cancel()">Cancel</button>
-  <button type="submit" class="btn btn-info" (click)="delete()">Delete</button>
+  <button type="submit" class="btn btn-danger" (click)="delete()">Delete</button>
 </div>

--- a/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
+++ b/src/app/views/sessions/session/dialogmodal/dialogmodal.service.ts
@@ -130,11 +130,12 @@ export class DialogModalService {
     return modalRef.result;
   }
 
-  openBooleanModal(title, message, okButtonText, cancelButtonText) {
+  openBooleanModal(title, message, okButtonText, cancelButtonText, okButtonClass = "btn-info") {
     const modalRef = this.modalService.open(BooleanModalComponent);
     modalRef.componentInstance.title = title;
     modalRef.componentInstance.message = message;
     modalRef.componentInstance.okButtonText = okButtonText;
+    modalRef.componentInstance.okButtonClass = okButtonClass;
     modalRef.componentInstance.cancelButtonText = cancelButtonText;
 
     return modalRef.result;

--- a/src/app/views/sessions/session/session-details/session-details.component.ts
+++ b/src/app/views/sessions/session/session-details/session-details.component.ts
@@ -93,7 +93,13 @@ export class SessionDetailsComponent {
 
   removeSessionModal() {
     this.dialogModalService
-      .openBooleanModal("Delete session", "Delete session " + this.sessionData.session.name + "?", "Delete", "Cancel")
+      .openBooleanModal(
+        "Delete session",
+        "Delete session " + this.sessionData.session.name + "?",
+        "Delete",
+        "Cancel",
+        "btn-danger",
+      )
       .then(
         () => {
           this.deleteSession.emit(this.session);

--- a/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
+++ b/src/app/views/sessions/session/visualization/phenodata/phenodata-visualization.component.ts
@@ -249,7 +249,13 @@ export class PhenodataVisualizationComponent implements OnInit, OnChanges, OnDes
         this.zone.run(() => {
           const columnName = this.headers[col];
           this.stringModalService
-            .openBooleanModal("Delete column", `Are you sure you want to delete column '${columnName}'?`, "Delete", "Cancel")
+            .openBooleanModal(
+              "Delete column",
+              `Are you sure you want to delete column '${columnName}'?`,
+              "Delete",
+              "Cancel",
+              "btn-danger",
+            )
             .then(() => this.removeColumn(col), () => {});
         });
       },


### PR DESCRIPTION
## Summary

Delete confirmation dialogs used the neutral `btn-info` styling on their confirm button. This makes destructive confirmations use the red `btn-danger` styling so the action reads clearly as destructive.

- `BooleanModalComponent` gained an optional `okButtonClass` input (default `btn-info`), threaded through `DialogModalService.openBooleanModal(...)`. Existing non-destructive callers (e.g. cancel-all-jobs) are unaffected.
- Switched the confirm button to `btn-danger` for:
  - Delete files/datasets (dedicated `DeleteFilesModalComponent`)
  - Delete session (session list + session details)
  - Delete phenodata column

## Test plan

- Delete a file, a session, and a phenodata column — confirm the Delete button is red in each dialog.
- Trigger cancel-all-jobs — confirm its button remains the default blue (btn-info).