### PR TITLE
Confirm before deleting news and removing shares

### DIFF
--- a/src/app/shared/components/news/news-list.component.ts
+++ b/src/app/shared/components/news/news-list.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from "@angular/core";
 import log from "loglevel";
 import { RestErrorService } from "../../../core/errorhandler/rest-error.service";
 import { LoadState } from "../../../model/loadstate";
+import { DialogModalService } from "../../../views/sessions/session/dialogmodal/dialogmodal.service";
 import { NewsService } from "../../services/news.service";
 import { NewsItem } from "./NewsItem";
 
@@ -19,6 +20,7 @@ export class NewsListComponent implements OnInit {
   constructor(
     private newsService: NewsService,
     private restErrorService: RestErrorService,
+    private dialogModalService: DialogModalService,
   ) {}
 
   ngOnInit(): void {
@@ -75,15 +77,24 @@ export class NewsListComponent implements OnInit {
       return;
     }
 
-    this.newsService.deleteNewsItem(news).subscribe({
-      next: () => {
-        log.info("delete news done");
-      },
-      error: (error) => {
-        log.warn("delete news failed", error);
-        this.restErrorService.showErrorAdmin("Delete news failed.", error);
-      },
-      complete: () => this.getNews(),
-    });
+    this.dialogModalService
+      .openBooleanModal("Delete news", `Delete news '${news.contents.title}'?`, "Delete", "Cancel", "btn-danger")
+      .then(
+        () => {
+          this.newsService.deleteNewsItem(news).subscribe({
+            next: () => {
+              log.info("delete news done");
+            },
+            error: (error) => {
+              log.warn("delete news failed", error);
+              this.restErrorService.showErrorAdmin("Delete news failed.", error);
+            },
+            complete: () => this.getNews(),
+          });
+        },
+        () => {
+          // modal dismissed
+        },
+      );
   }
 }

--- a/src/app/views/sessions/session-list.component.ts
+++ b/src/app/views/sessions/session-list.component.ts
@@ -494,9 +494,18 @@ export class SessionListComponent implements OnInit, OnDestroy {
   }
 
   deleteRule(session: Session, rule: Rule) {
-    this.sessionResource.deleteRule(session.sessionId, rule.ruleId).subscribe(null, (error: any) => {
-      this.restErrorService.showError("Deleting the share failed", error);
-    });
+    this.dialogModalService
+      .openBooleanModal("Remove shared session", `Remove shared session '${session.name}'?`, "Remove", "Cancel")
+      .then(
+        () => {
+          this.sessionResource.deleteRule(session.sessionId, rule.ruleId).subscribe(null, (error: any) => {
+            this.restErrorService.showError("Deleting the share failed", error);
+          });
+        },
+        () => {
+          // modal dismissed
+        },
+      );
   }
 
   isSessionSelected(session: Session) {

--- a/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.ts
+++ b/src/app/views/sessions/session/dialogmodal/share-session-modal/share-session-modal.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, Input, OnDestroy, OnInit, ViewChild } from "@angular/core";
-import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
+import { NgbActiveModal, NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Rule, Session, SessionEvent } from "chipster-js-common";
 import log from "loglevel";
 import { Observable, Subject } from "rxjs";
@@ -8,6 +8,7 @@ import { TokenService } from "../../../../../core/authentication/token.service";
 import { ErrorService } from "../../../../../core/errorhandler/error.service";
 import { RestErrorService } from "../../../../../core/errorhandler/rest-error.service";
 import { SessionResource } from "../../../../../shared/resources/session.resource";
+import { BooleanModalComponent } from "../booleanmodal/booleanmodal.component";
 
 @Component({
   templateUrl: "./share-session-modal.component.html",
@@ -34,6 +35,7 @@ export class SharingModalComponent implements AfterViewInit, OnInit, OnDestroy {
     private restErrorService: RestErrorService,
     private sessionResource: SessionResource,
     private errorService: ErrorService,
+    private modalService: NgbModal,
   ) {}
 
   ngOnInit() {
@@ -90,9 +92,26 @@ export class SharingModalComponent implements AfterViewInit, OnInit, OnDestroy {
   }
 
   deleteRule(ruleId: string) {
-    this.sessionResource.deleteRule(this.session.sessionId, ruleId).subscribe(
-      (resp) => log.info("rule deleted"),
-      (err) => this.restErrorService.showError("failed to delete the rule", err),
+    const rule = this.rules.find((r) => r.ruleId === ruleId);
+    const username = rule ? rule.username : "";
+
+    // open BooleanModalComponent directly instead of via DialogModalService, which would create a
+    // circular dependency (DialogModalService opens this SharingModalComponent)
+    const modalRef = this.modalService.open(BooleanModalComponent);
+    modalRef.componentInstance.title = "Stop sharing";
+    modalRef.componentInstance.message = `Stop sharing with ${username}?`;
+    modalRef.componentInstance.okButtonText = "Stop sharing";
+    modalRef.componentInstance.cancelButtonText = "Cancel";
+    modalRef.result.then(
+      () => {
+        this.sessionResource.deleteRule(this.session.sessionId, ruleId).subscribe(
+          (resp) => log.info("rule deleted"),
+          (err) => this.restErrorService.showError("failed to delete the rule", err),
+        );
+      },
+      () => {
+        // modal dismissed
+      },
     );
   }
 


### PR DESCRIPTION
## Summary

Three destructive actions previously executed immediately on click, with no confirmation. This adds an "Are you sure?" dialog to each:

- **Delete news** — confirms `Delete news '<title>'?` (red danger button).
- **Remove shared session** ("Shared with me" list) — confirms `Remove shared session '<name>'?`.
- **Stop sharing** (Share Session modal) — confirms `Stop sharing with <username>?`.

The remove-share / stop-sharing dialogs use the default (neutral) button; only news delete uses the danger styling.

### Note on the share modal

`SharingModalComponent` is itself opened by `DialogModalService`, so injecting that service back into it would create a circular dependency. Instead it opens `BooleanModalComponent` directly via `NgbModal` (a comment in the code explains this).

## Test plan

- Delete a news item → confirm the dialog appears with a red Delete button; cancel leaves it intact.
- Remove a session from "Shared with me" → confirm the dialog appears; cancel keeps the share.
- In the Share Session modal, revoke a user's access → confirm the (stacked) dialog appears and works; cancel keeps the rule.