### PR TITLE
Don't let single-key shortcuts swallow Cmd/Ctrl browser shortcuts

### DIFF
--- a/src/app/shared/services/hotkey.service.ts
+++ b/src/app/shared/services/hotkey.service.ts
@@ -25,6 +25,11 @@ export class HotkeyService {
     ) {
       return;
     }
+    // Ignore combinations with a command modifier so single-letter shortcuts
+    // don't swallow native browser shortcuts like Cmd/Ctrl+L and Cmd/Ctrl+F.
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
     const shortcut = this.shortcuts.get(event.key.toLowerCase());
     if (shortcut) {
       event.preventDefault();


### PR DESCRIPTION
## Problem

The keyboard-shortcut handler matched on the bare letter (`event.key`) and called `event.preventDefault()` without checking modifier keys. As a result, native browser shortcuts that the page is allowed to cancel were hijacked:

- **Cmd/Ctrl+L** triggered "Open labels" instead of focusing the address bar
- **Cmd/Ctrl+F** triggered "Find file" instead of browser find-in-page

(Cmd+T etc. appeared unaffected only because the browser doesn't deliver those keydowns to the page as cancelable.)

## Fix

Skip the shortcut lookup when a command modifier (`metaKey` / `ctrlKey` / `altKey`) is held, so combinations pass straight through to the browser. Bare `t` / `j` / `l` / `f` / `?` still work.

`shiftKey` is intentionally **not** excluded, so `?` (Shift+/) still opens the shortcuts cheatsheet.