### PR TITLE
Add 'H' shortcut for keyboard shortcuts help modal

### DIFF
--- a/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.html
+++ b/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.html
@@ -6,7 +6,11 @@
   <div class="modal-body">
     <dl>
       <ng-container *ngFor="let shortcut of shortcuts">
-        <dt><kbd>{{ shortcut.key }}</kbd></dt>
+        <dt>
+          <ng-container *ngFor="let key of shortcut.keys; let last = last">
+            <kbd>{{ key }}</kbd><span *ngIf="!last"> / </span>
+          </ng-container>
+        </dt>
         <dd>{{ shortcut.description }}</dd>
       </ng-container>
     </dl>

--- a/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.ts
+++ b/src/app/shared/components/hotkey-cheatsheet/hotkey-cheatsheet.component.ts
@@ -11,7 +11,7 @@ import { HotkeyService } from "../../services/hotkey.service";
 export class HotkeyCheatsheetComponent implements OnInit, OnDestroy {
   @ViewChild("content") contentTemplate!: TemplateRef<unknown>;
 
-  private unregister!: () => void;
+  private readonly unregister: Array<() => void> = [];
   private modalRef: NgbModalRef | null = null;
 
   constructor(
@@ -20,24 +20,32 @@ export class HotkeyCheatsheetComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.unregister = this.hotkeyService.register("?", "Show keyboard shortcuts", () => {
+    const open = () => {
       if (this.hotkeyService.getShortcuts().length > 0) {
         this.toggle();
       }
-    });
+    };
+    this.unregister.push(
+      this.hotkeyService.register("?", "Show keyboard shortcuts", open),
+      this.hotkeyService.register("h", "Show keyboard shortcuts", open),
+    );
   }
 
   ngOnDestroy() {
-    this.unregister();
+    this.unregister.forEach((fn) => fn());
     this.modalRef?.close();
   }
 
-  get shortcuts() {
-    return this.hotkeyService.getShortcuts().sort((a, b) => {
-      if (a.key === "?") return 1;
-      if (b.key === "?") return -1;
-      return 0;
-    });
+  get shortcuts(): Array<{ keys: string[]; description: string }> {
+    // "h" and "?" both open this modal; show them as a single "H / ?" row last,
+    // with each key in its own <kbd> and the "/" separator left unstyled.
+    const helpKeys = new Set(["h", "?"]);
+    const rows = this.hotkeyService
+      .getShortcuts()
+      .filter((s) => !helpKeys.has(s.key))
+      .map((s) => ({ keys: [s.key], description: s.description }));
+    rows.push({ keys: ["H", "?"], description: "Show keyboard shortcuts" });
+    return rows;
   }
 
   close() {


### PR DESCRIPTION
## What

Adds **H** as an alternative to **?** for opening the keyboard-shortcuts help modal — `h` is easier to reach than Shift+/ on many layouts.

## Changes

- Register `h` alongside `?` in `HotkeyCheatsheetComponent`; both open the modal.
- In the cheatsheet, the two are collapsed into a single trailing row rendered as `H / ?`, with each key in its own `<kbd>` and the `/` separator left unstyled.

## Notes

Branched off `master`, so it doesn't include the Cmd/Ctrl modifier guard from #51 — once that merges, `h` will also correctly ignore Cmd+H.