### PR TITLE
Fix empty plot when opening visualization tab

### DIFF
--- a/src/app/shared/visualization/plot.directive.ts
+++ b/src/app/shared/visualization/plot.directive.ts
@@ -1,6 +1,6 @@
 // Super class for scatterplot and volcanoplot
 
-import { Directive, HostListener, Input, OnChanges, OnDestroy } from "@angular/core";
+import { Directive, Input, OnChanges, OnDestroy } from "@angular/core";
 import { Dataset } from "chipster-js-common";
 import * as d3 from "d3";
 import { Subject } from "rxjs";
@@ -38,6 +38,9 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
 
   protected unsubscribe: Subject<any> = new Subject();
   state: LoadState;
+
+  // Redraws the plot when its container changes size, see observePlotResize()
+  private resizeObserver: ResizeObserver;
 
   constructor(fileResource: FileResource, sessionDataService: SessionDataService) {
     this.fileResource = fileResource;
@@ -104,6 +107,10 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
   ngOnDestroy() {
     this.unsubscribe.next(null);
     this.unsubscribe.complete();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = undefined;
+    }
   }
 
   /** @description To check whether the file has the required column headers to create the visualization* */
@@ -215,9 +222,26 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
   /** @description New Dataset Creation  from selected data points * */
   createDatasetFromSelected() {}
 
-  // Redraw the svg with the changed width of the window
-  @HostListener("window:resize", ["$event"])
-  onResize(event: any) {
-    this.redrawPlot();
+  /**
+   * Redraw the plot whenever its container changes size.
+   *
+   * The plot is drawn into a tab that ngbNav creates lazily. When the tab
+   * becomes visible the container doesn't necessarily have its final width
+   * yet, so the first draw can end up with a zero/wrong width and an empty
+   * plot. Observing the container redraws the plot once it gets its real
+   * size, and also takes care of redrawing on window resize.
+   *
+   * Safe to call repeatedly; the observer is only created once.
+   */
+  protected observePlotResize(element: Element) {
+    if (!element || this.resizeObserver) {
+      return;
+    }
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.tsv && this.selectedXAxisHeader) {
+        this.redrawPlot();
+      }
+    });
+    this.resizeObserver.observe(element);
   }
 }

--- a/src/app/shared/visualization/plot.directive.ts
+++ b/src/app/shared/visualization/plot.directive.ts
@@ -1,6 +1,6 @@
 // Super class for scatterplot and volcanoplot
 
-import { Directive, Input, OnChanges, OnDestroy } from "@angular/core";
+import { Directive, Input, NgZone, OnChanges, OnDestroy } from "@angular/core";
 import { Dataset } from "chipster-js-common";
 import * as d3 from "d3";
 import { Subject } from "rxjs";
@@ -35,17 +35,20 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
   protected fileResource: FileResource;
   protected sessionDataService: SessionDataService;
   private restErrorService: RestErrorService;
+  private zone: NgZone;
 
   protected unsubscribe: Subject<any> = new Subject();
   state: LoadState;
 
-  // Redraws the plot when its container changes size, see observePlotResize()
+  // Redraws the plot when its container changes width, see observePlotResize()
   private resizeObserver: ResizeObserver;
+  private lastPlotWidth: number;
 
   constructor(fileResource: FileResource, sessionDataService: SessionDataService) {
     this.fileResource = fileResource;
     this.sessionDataService = sessionDataService;
     this.restErrorService = AppInjector.get(RestErrorService);
+    this.zone = AppInjector.get(NgZone);
   }
 
   ngOnChanges() {
@@ -58,6 +61,14 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
     this.unsubscribe.next(null);
 
     this.clearPlot();
+
+    // clear any previous selection so it isn't re-applied to a new dataset
+    this.selectedDataPointIds = undefined;
+    this.selectedDataRows = [];
+
+    // reset the cached width so the resize observer redraws the new dataset
+    // even when the container returns to a width it had for a previous one
+    this.lastPlotWidth = undefined;
 
     let rowLimit = 5000;
     if (showMore) {
@@ -223,13 +234,17 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
   createDatasetFromSelected() {}
 
   /**
-   * Redraw the plot whenever its container changes size.
+   * Redraw the plot whenever its container changes width.
    *
    * The plot is drawn into a tab that ngbNav creates lazily. When the tab
    * becomes visible the container doesn't necessarily have its final width
    * yet, so the first draw can end up with a zero/wrong width and an empty
    * plot. Observing the container redraws the plot once it gets its real
-   * size, and also takes care of redrawing on window resize.
+   * width, and also takes care of redrawing on window resize.
+   *
+   * Only width changes trigger a redraw: the plot height is fixed, so
+   * height-only changes (e.g. the selection list growing the panel) must
+   * not redraw, otherwise the current selection highlight would be lost.
    *
    * Safe to call repeatedly; the observer is only created once.
    */
@@ -237,9 +252,14 @@ export abstract class PlotDirective implements OnChanges, OnDestroy {
     if (!element || this.resizeObserver) {
       return;
     }
-    this.resizeObserver = new ResizeObserver(() => {
-      if (this.tsv && this.selectedXAxisHeader) {
-        this.redrawPlot();
+    this.resizeObserver = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width && width !== this.lastPlotWidth && this.tsv && this.selectedXAxisHeader) {
+        this.lastPlotWidth = width;
+        // ResizeObserver fires outside Angular's zone; redraw inside it so the
+        // d3 drag handlers are re-registered in the zone (otherwise selecting
+        // would not trigger change detection) and bound state stays in sync.
+        this.zone.run(() => this.redrawPlot());
       }
     });
     this.resizeObserver.observe(element);

--- a/src/app/views/sessions/session/visualization/expression-profile/expression-profile.component.ts
+++ b/src/app/views/sessions/session/visualization/expression-profile/expression-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, ViewEncapsulation } from "@angular/core";
+import { Component, Input, NgZone, OnChanges, OnDestroy, ViewEncapsulation } from "@angular/core";
 import { Dataset } from "chipster-js-common";
 import * as d3 from "d3";
 import { filter, map, find, difference, uniq, includes, floor, intersection } from "lodash-es";
@@ -36,8 +36,9 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
   private unsubscribe: Subject<any> = new Subject();
   state: LoadState;
 
-  // Redraws the chart when its container changes size, see observeResize()
+  // Redraws the chart when its container changes width, see observeResize()
   private resizeObserver: ResizeObserver;
+  private lastChartWidth: number;
 
   constructor(
     private expressionProfileService: ExpressionProfileService,
@@ -45,6 +46,7 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
     private visualizationTSVService: VisualizationTSVService,
     private fileResource: FileResource,
     private restErrorService: RestErrorService,
+    private zone: NgZone,
   ) {}
 
   ngOnChanges() {
@@ -87,6 +89,10 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
       );
 
     this.selectedGeneExpressions = [];
+
+    // reset the cached width so the resize observer redraws the new dataset
+    // even when the container returns to a width it had for a previous one
+    this.lastChartWidth = undefined;
   }
 
   ngOnDestroy() {
@@ -114,9 +120,17 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
     if (!element || this.resizeObserver) {
       return;
     }
-    this.resizeObserver = new ResizeObserver(() => {
-      if (this.tsv) {
-        this.drawLineChart(this.tsv);
+    this.resizeObserver = new ResizeObserver((entries) => {
+      // Only width changes trigger a redraw: the chart height is fixed, so
+      // height-only changes (e.g. the selection list growing the panel) must
+      // not redraw, otherwise the current selection highlight would be lost.
+      const width = entries[0]?.contentRect.width;
+      if (width && width !== this.lastChartWidth && this.tsv) {
+        this.lastChartWidth = width;
+        // ResizeObserver fires outside Angular's zone; redraw inside it so the
+        // d3 drag handlers are re-registered in the zone (otherwise selecting
+        // would not trigger change detection) and bound state stays in sync.
+        this.zone.run(() => this.drawLineChart(this.tsv));
       }
     });
     this.resizeObserver.observe(element);
@@ -357,6 +371,9 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
       startPoint = new Point(-1, -1);
       d3.select(".band").attr("width", 0).attr("height", 0).attr("x", 0).attr("y", 0);
     }
+
+    // the paths are recreated on every redraw, so re-apply the selection highlight
+    (this.selectedGeneExpressions ?? []).forEach((expression) => this.setSelectionStyle(expression.id));
   }
 
   createNewDataset() {

--- a/src/app/views/sessions/session/visualization/expression-profile/expression-profile.component.ts
+++ b/src/app/views/sessions/session/visualization/expression-profile/expression-profile.component.ts
@@ -36,6 +36,9 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
   private unsubscribe: Subject<any> = new Subject();
   state: LoadState;
 
+  // Redraws the chart when its container changes size, see observeResize()
+  private resizeObserver: ResizeObserver;
+
   constructor(
     private expressionProfileService: ExpressionProfileService,
     private sessionDataService: SessionDataService,
@@ -68,6 +71,7 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
           this.tsv = new TSVFile(parsedTSV, this.dataset.datasetId, datasetName);
           if (this.visualizationTSVService.containsChipHeaders(this.tsv)) {
             this.drawLineChart(this.tsv);
+            this.observeResize();
             this.state = new LoadState(State.Ready);
           } else {
             this.state = new LoadState(
@@ -88,6 +92,34 @@ export class ExpressionProfileComponent implements OnChanges, OnDestroy {
   ngOnDestroy() {
     this.unsubscribe.next(null);
     this.unsubscribe.complete();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = undefined;
+    }
+  }
+
+  /**
+   * Redraw the chart whenever its container changes size.
+   *
+   * The chart is drawn into a tab that ngbNav creates lazily. When the tab
+   * becomes visible the container doesn't necessarily have its final width
+   * yet, so the first draw can end up with a zero/wrong width and an empty
+   * chart. Observing the container redraws the chart once it gets its real
+   * size, and also takes care of redrawing on window resize.
+   *
+   * Safe to call repeatedly; the observer is only created once.
+   */
+  private observeResize() {
+    const element = document.getElementById("expressionprofile");
+    if (!element || this.resizeObserver) {
+      return;
+    }
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.tsv) {
+        this.drawLineChart(this.tsv);
+      }
+    });
+    this.resizeObserver.observe(element);
   }
 
   drawLineChart(tsv: TSVFile) {

--- a/src/app/views/sessions/session/visualization/scatter-plot/scatter-plot.component.ts
+++ b/src/app/views/sessions/session/visualization/scatter-plot/scatter-plot.component.ts
@@ -204,6 +204,8 @@ export class ScatterPlotComponent extends PlotDirective implements OnChanges, On
     super.clearPlot();
     this.svg = this.plot.append("svg");
     this.populatePlotData();
+    // the points are recreated on every redraw, so re-apply the selection highlight
+    this.selectedDataPointIds?.forEach((id) => this.setSelectionStyle(id));
     this.observePlotResize(this.plot.node());
   }
 

--- a/src/app/views/sessions/session/visualization/scatter-plot/scatter-plot.component.ts
+++ b/src/app/views/sessions/session/visualization/scatter-plot/scatter-plot.component.ts
@@ -204,6 +204,7 @@ export class ScatterPlotComponent extends PlotDirective implements OnChanges, On
     super.clearPlot();
     this.svg = this.plot.append("svg");
     this.populatePlotData();
+    this.observePlotResize(this.plot.node());
   }
 
   // New Dataset Creation  from selected data points

--- a/src/app/views/sessions/session/visualization/volcano-plot/volcano-plot.component.ts
+++ b/src/app/views/sessions/session/visualization/volcano-plot/volcano-plot.component.ts
@@ -249,6 +249,8 @@ export class VolcanoPlotComponent extends PlotDirective implements OnChanges, On
     super.clearPlot();
     this.svg = this.plot.append("svg");
     this.populatePlotData();
+    // the points are recreated on every redraw, so re-apply the selection highlight
+    this.selectedDataPointIds?.forEach((id) => this.setSelectionStyle(id));
     this.observePlotResize(this.plot.node());
   }
 

--- a/src/app/views/sessions/session/visualization/volcano-plot/volcano-plot.component.ts
+++ b/src/app/views/sessions/session/visualization/volcano-plot/volcano-plot.component.ts
@@ -249,6 +249,7 @@ export class VolcanoPlotComponent extends PlotDirective implements OnChanges, On
     super.clearPlot();
     this.svg = this.plot.append("svg");
     this.populatePlotData();
+    this.observePlotResize(this.plot.node());
   }
 
   // new Dataset creation


### PR DESCRIPTION
## Problem

Scatter, volcano, and expression-profile plots are drawn into a tab that ngbNav creates lazily. When the tab first becomes visible the container doesn't yet have its final width, so the initial draw could end up zero/wrong width — an empty plot.

Resize handling also redrew on **any** container size change, which wiped the current selection highlight whenever a height-only change (e.g. the selection list growing the panel) fired.

## Changes

- Replace the `window:resize` `@HostListener` with a `ResizeObserver` on each plot's container, so the plot redraws once the container gets its real width (fixing the empty plot) and on later width changes.
- Redraw **only** when the container width actually changes; height-only changes no longer trigger a redraw, so the selection highlight is preserved.
- Re-apply the selection highlight after each redraw, since the points/paths are recreated.
- Reset the cached width when a new dataset loads, so the observer still redraws the new dataset even when the container returns to a width a previous dataset had used (otherwise the corrective redraw would be suppressed and the plot would stay empty).
- Run the observer redraw inside Angular's zone so d3 drag handlers re-register in the zone and selection triggers change detection.

## Affected

- `plot.directive.ts` (shared base for scatter + volcano)
- `scatter-plot.component.ts`, `volcano-plot.component.ts`
- `expression-profile.component.ts`